### PR TITLE
Changed the behavior when the template fails to get a runtime value f…

### DIFF
--- a/Engine/Quokka.Core/Mindbox.Quokka.csproj
+++ b/Engine/Quokka.Core/Mindbox.Quokka.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net47</TargetFramework>
     <NoWarn>1701;1702;1705;3021</NoWarn>
     <Company>Mindbox</Company>
-    <Version>3.1.3</Version>
+    <Version>3.2.0</Version>
     <Product>Quokka template engine</Product>
     <Description>String templating library</Description>
     <Copyright>Mindbox 2017</Copyright>

--- a/Engine/Quokka.Core/Rendering/RuntimeVariableScope.cs
+++ b/Engine/Quokka.Core/Rendering/RuntimeVariableScope.cs
@@ -26,13 +26,9 @@ namespace Mindbox.Quokka
 		
 		public VariableValueStorage TryGetValueStorageForVariable(string variableName)
 		{
-			if (valueStorage.ContainsValueForVariable(variableName))
-				return valueStorage.GetFieldValueStorage(variableName);
-
-			if (parentScope == null)
-				throw new InvalidOperationException($"Value for variable {variableName} not found");
-
-			return parentScope.TryGetValueStorageForVariable(variableName);
+			return valueStorage.ContainsValueForVariable(variableName) 
+						? valueStorage.GetFieldValueStorage(variableName) 
+						: parentScope?.TryGetValueStorageForVariable(variableName);
 		}
 
 		public void TrySetValueStorageForVariable(string variableName, VariableValueStorage value)

--- a/Engine/Quokka.Core/Templating/Expressions/Variables/VariableValueExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Variables/VariableValueExpression.cs
@@ -67,7 +67,10 @@ namespace Mindbox.Quokka
 		
 		public VariableValueStorage TryGetValueStorage(RenderContext renderContext)
 		{
-			return renderContext.VariableScope.TryGetValueStorageForVariable(variableName);
+			return renderContext.VariableScope.TryGetValueStorageForVariable(variableName) ??
+					throw new UnrenderableTemplateModelException(
+						$"Value for variable {variableName} not found",
+						variableLocation);
 		}
 
 

--- a/Engine/Quokka.Tests/Helpers/TemplateAssert.cs
+++ b/Engine/Quokka.Tests/Helpers/TemplateAssert.cs
@@ -92,13 +92,6 @@ namespace Mindbox.Quokka.Tests
 
 				Assert.AreEqual(expectedPrimitiveDefinition.Type, actualPrimitiveDefinition.Type);
 			}
-			else if (expected is ICompositeModelDefinition expectedCompositeDefinition)
-			{
-				Assert.IsInstanceOfType(actual, typeof(ICompositeModelDefinition));
-				var actualCompositeDefinition = (ICompositeModelDefinition)actual;
-
-				AreCompositeModelDefinitionsEqual(expectedCompositeDefinition, actualCompositeDefinition);
-			}
 			else if (expected is IArrayModelDefinition expectedArrayDefinition)
 			{
 				Assert.IsInstanceOfType(actual, typeof(IArrayModelDefinition));
@@ -108,6 +101,13 @@ namespace Mindbox.Quokka.Tests
 				AreModelDefinitionsEquivalent(
 					expectedArrayDefinition.ElementModelDefinition,
 					actualArrayDefinition.ElementModelDefinition);
+			}
+			else if (expected is ICompositeModelDefinition expectedCompositeDefinition)
+			{
+				Assert.IsInstanceOfType(actual, typeof(ICompositeModelDefinition));
+				var actualCompositeDefinition = (ICompositeModelDefinition)actual;
+
+				AreCompositeModelDefinitionsEqual(expectedCompositeDefinition, actualCompositeDefinition);
 			}
 			else
 			{

--- a/Engine/Quokka.Tests/Rendering/RenderExceptionsTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderExceptionsTests.cs
@@ -30,7 +30,25 @@ namespace Mindbox.Quokka
 			template.Render(new CompositeModelValue());
 		}
 
-	    private class FaultyFunction : ScalarTemplateFunction
+
+		[TestMethod]
+		[ExpectedException(typeof(UnrenderableTemplateModelException))]
+		public void Render_AssignmentBlock_AssignmentInsideEmptyLoop()
+		{
+			var template = new Template(@"
+				@{ for p in ps }
+					@{ set a = 5 }
+				@{ end for }
+
+				${ a }");
+
+			var result = template.Render(
+				new CompositeModelValue(
+					new ModelField("ps",
+						new ArrayModelValue())));
+		}
+
+		private class FaultyFunction : ScalarTemplateFunction
 	    {
 		    public FaultyFunction() 
 				: base("fail", typeof(int))


### PR DESCRIPTION
…or a variable. Before the assignment operator was introduced, this situation was always a bug. Now, with assignment in the picture, it can occur in some scenarios caused by the user, so it makes more sense to throw a UnrendereableTemplateModelException.