### PR TITLE
Fixed a corner case in ModelDefinition combining logic. Unknown types…

### DIFF
--- a/Engine/Quokka.Core/Mindbox.Quokka.csproj
+++ b/Engine/Quokka.Core/Mindbox.Quokka.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>1701;1702;1705;3021</NoWarn>
     <Company>Mindbox</Company>
-    <Version>3.8.4</Version>
+    <Version>3.9.0</Version>
     <Product>Quokka template engine</Product>
     <Description>String templating library</Description>
     <Copyright>Mindbox 2017</Copyright>

--- a/Engine/Quokka.Tests/ModelValidation/ModelDefinitionCombiningTests.cs
+++ b/Engine/Quokka.Tests/ModelValidation/ModelDefinitionCombiningTests.cs
@@ -404,5 +404,130 @@ namespace Mindbox.Quokka.Tests
 					}),
 				combinedDefinition);
 		}
+
+		[TestMethod]
+		public void DefinitionCombining_ArrayOfUnknowns_MergeWithArrayOfComposites()
+		{
+			var definition1 = new CompositeModelDefinition(
+				new Dictionary<string, IModelDefinition>
+				{
+					{
+						"Array",
+						new ArrayModelDefinition(new PrimitiveModelDefinition(TypeDefinition.Unknown))
+					}
+				});
+
+			var definition2 = new CompositeModelDefinition(
+				new Dictionary<string, IModelDefinition>
+				{
+					{
+						"Array",
+						new ArrayModelDefinition(
+							new CompositeModelDefinition(
+								new Dictionary<string, IModelDefinition>
+								{
+									{ "Name", new PrimitiveModelDefinition(TypeDefinition.String) }
+								}))
+					}
+				});
+
+			var combinedDefinition = new DefaultTemplateFactory().CombineModelDefinition(new[] { definition1, definition2 });
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Array",
+							new ArrayModelDefinition(
+								new CompositeModelDefinition(
+									new Dictionary<string, IModelDefinition>
+									{
+										{ "Name", new PrimitiveModelDefinition(TypeDefinition.String) }
+									}))
+						}
+					}),
+				combinedDefinition);
+		}
+		
+		[TestMethod]
+		public void DefinitionCombining_ArrayOfComposites_MergeWithArrayOfUnknowns()
+		{
+			var definition1 = new CompositeModelDefinition(
+				new Dictionary<string, IModelDefinition>
+				{
+					{
+						"Array",
+						new ArrayModelDefinition(
+							new CompositeModelDefinition(
+								new Dictionary<string, IModelDefinition>
+								{
+									{ "Name", new PrimitiveModelDefinition(TypeDefinition.String) }
+								}))
+					}
+				});
+
+			var definition2 = new CompositeModelDefinition(
+				new Dictionary<string, IModelDefinition>
+				{
+					{
+						"Array",
+						new ArrayModelDefinition(new PrimitiveModelDefinition(TypeDefinition.Unknown))
+					}
+				});
+
+			var combinedDefinition = new DefaultTemplateFactory().CombineModelDefinition(new[] { definition1, definition2 });
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Array",
+							new ArrayModelDefinition(
+								new CompositeModelDefinition(
+									new Dictionary<string, IModelDefinition>
+									{
+										{ "Name", new PrimitiveModelDefinition(TypeDefinition.String) }
+									}))
+						}
+					}),
+				combinedDefinition);
+		}
+
+		[TestMethod]
+		public void DefinitionCombining_Unknown_MergingWithUnknown()
+		{
+			var definition1 = new CompositeModelDefinition(
+				new Dictionary<string, IModelDefinition>
+				{
+					{
+						"Thing",
+						new PrimitiveModelDefinition(TypeDefinition.Unknown)
+					}
+				});
+
+			var definition2 = new CompositeModelDefinition(
+				new Dictionary<string, IModelDefinition>
+				{
+					{
+						"Thing",
+						new PrimitiveModelDefinition(TypeDefinition.Unknown)
+					}
+				});
+
+			var combinedDefinition = new DefaultTemplateFactory().CombineModelDefinition(new[] { definition1, definition2 });
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Thing",
+							new PrimitiveModelDefinition(TypeDefinition.Unknown)
+						}
+					}),
+			combinedDefinition);
+		}
 	}
 }


### PR DESCRIPTION
… are now correctly merged with Composites and Arrays.