### PR TITLE
Added proper static analysis of method calls on tableRows(..) results…

### DIFF
--- a/Engine/Quokka.Core/Errors/ISemanticErrorListener.cs
+++ b/Engine/Quokka.Core/Errors/ISemanticErrorListener.cs
@@ -67,5 +67,9 @@ namespace Mindbox.Quokka
 			string methodName,
 			int argumentPosition,
 			Location location);
+
+		void AddUnexpectedMethodOnCompositeDeclaredTypeError(
+			ValueUsageSummary definition,
+			Location location);
 	}
 }

--- a/Engine/Quokka.Core/Errors/SemanticErrorListener.cs
+++ b/Engine/Quokka.Core/Errors/SemanticErrorListener.cs
@@ -129,6 +129,15 @@ namespace Mindbox.Quokka
 				location));
 		}
 
+		public void AddUnexpectedMethodOnCompositeDeclaredTypeError(
+			ValueUsageSummary definition,
+			Location location)
+		{
+			AddError(new SemanticError(
+				$"Неизвестный метод \"{definition.FullName}\"",
+				location));
+		}
+
 		public void AddVariableDeclarationScopeConflictError(ValueUsageSummary definition, Location location)
 		{
 			AddError(new SemanticError(

--- a/Engine/Quokka.Core/Semantics/Variables/ValueUsageSummary.cs
+++ b/Engine/Quokka.Core/Semantics/Variables/ValueUsageSummary.cs
@@ -272,10 +272,23 @@ namespace Mindbox.Quokka
 
 			foreach (var actualItem in Fields.Items)
 			{
-				IModelDefinition fieldExpectedDefinition;
-				if (expectedModelDefinition.Fields.TryGetValue(actualItem.Key, out fieldExpectedDefinition))
+				if (expectedModelDefinition.Fields.TryGetValue(actualItem.Key, out var fieldExpectedDefinition))
 				{
 					actualItem.Value.ValidateAgainstExpectedModelDefinition(fieldExpectedDefinition, errorListener);
+				}
+				else
+				{
+					errorListener.AddUnexpectedFieldOnCompositeDeclaredTypeError(
+						actualItem.Value,
+						actualItem.Value.GetFirstLocation());
+				}
+			}
+
+			foreach (var actualItem in Methods.Items)
+			{
+				if (expectedModelDefinition.Methods.TryGetValue(actualItem.Key.ToMethodCallDefinition(), out var methodExpectedDefinition))
+				{
+					actualItem.Value.ValidateAgainstExpectedModelDefinition(methodExpectedDefinition, errorListener);
 				}
 				else
 				{

--- a/Engine/Quokka.Tests/Creating/StaticErrorsOnTableRowsTests.cs
+++ b/Engine/Quokka.Tests/Creating/StaticErrorsOnTableRowsTests.cs
@@ -49,6 +49,17 @@ namespace Mindbox.Quokka.Tests
 
 		[TestMethod]
 		[ExpectedException(typeof(TemplateContainsErrorsException))]
+		public void CreateTemplate_TableRows_UndefinedMethodOnRow_Error()
+		{
+			new Template(@"
+				@{ for row in tableRows(Collection, 3) }
+					${ row.DoSomething() }
+				@{ end for }
+			");
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(TemplateContainsErrorsException))]
 		public void CreateTemplate_TableRows_TreatingCellsAsPrimitive_Error()
 		{
 			new Template(@"


### PR DESCRIPTION
… ("row.IsSomething()" is no longer valid at compile-time)