### PR TITLE
Mailings #1195

### DIFF
--- a/Engine/Mindbox.Quokka.Abstractions/ITemplate.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/ITemplate.cs
@@ -15,6 +15,8 @@
 using System.Collections.Generic;
 using System.IO;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	public interface ITemplate
@@ -26,7 +28,11 @@ namespace Mindbox.Quokka
 		ICompositeModelDefinition GetModelDefinition();
 
 		string Render(ICompositeModelValue model, ICallContextContainer callContextContainer = null);
+		
+		string Render(ICompositeModelValue model, RenderSettings settings, ICallContextContainer callContextContainer = null);
 
 		void Render(TextWriter textWriter, ICompositeModelValue model, ICallContextContainer callContextContainer = null);
+		
+		void Render(TextWriter textWriter, ICompositeModelValue model, RenderSettings settings, ICallContextContainer callContextContainer = null);
 	}
 }

--- a/Engine/Mindbox.Quokka.Abstractions/Settings/RenderSettings.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Settings/RenderSettings.cs
@@ -1,0 +1,13 @@
+﻿using System.Globalization;
+
+namespace Mindbox.Quokka.Abstractions;
+
+public class RenderSettings
+{
+    public static RenderSettings Default = new()
+    {
+        CultureInfo = CultureInfo.CurrentCulture
+    };
+    
+    public CultureInfo CultureInfo { get; set; }
+}

--- a/Engine/Mindbox.Quokka.Abstractions/Settings/RenderSettings.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Settings/RenderSettings.cs
@@ -1,4 +1,18 @@
-﻿using System.Globalization;
+﻿// // Copyright 2022 Mindbox Ltd
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+using System.Globalization;
 
 namespace Mindbox.Quokka.Abstractions;
 

--- a/Engine/Quokka.Core/Functions/ScalarTemplateFunction`1.cs
+++ b/Engine/Quokka.Core/Functions/ScalarTemplateFunction`1.cs
@@ -15,6 +15,8 @@
 using System;
 using System.Collections.Generic;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	public abstract class ScalarTemplateFunction<TArgument, TResult> : ScalarTemplateFunction
@@ -27,7 +29,7 @@ namespace Mindbox.Quokka
 			this.argument = argument;
 		}
 
-		public abstract TResult Invoke(TArgument value);
+		public abstract TResult Invoke(RenderSettings settings, TArgument value);
 
 		internal override object GetScalarInvocationResult(
 			RenderContext renderContext,
@@ -36,7 +38,7 @@ namespace Mindbox.Quokka
 			if (argumentsValues.Count != 1)
 				throw new InvalidOperationException($"Function that expects 1 argument was passed {argumentsValues.Count}");
 
-			return Invoke(argument.ConvertValue(argumentsValues[0]));
+			return Invoke(renderContext.Settings, argument.ConvertValue(argumentsValues[0]));
 		}
 	}
 }

--- a/Engine/Quokka.Core/Functions/ScalarTemplateFunction`2.cs
+++ b/Engine/Quokka.Core/Functions/ScalarTemplateFunction`2.cs
@@ -15,6 +15,8 @@
 using System;
 using System.Collections.Generic;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	public abstract class ScalarTemplateFunction<TArgument1, TArgument2, TResult> : ScalarTemplateFunction
@@ -32,7 +34,7 @@ namespace Mindbox.Quokka
 			this.argument2 = argument2;
 		}
 
-		public abstract TResult Invoke(TArgument1 value1, TArgument2 value2);
+		public abstract TResult Invoke(RenderSettings settings, TArgument1 value1, TArgument2 value2);
 
 		internal override object GetScalarInvocationResult(
 			RenderContext renderContext,
@@ -42,7 +44,8 @@ namespace Mindbox.Quokka
 				throw new InvalidOperationException($"Function that expects 2 arguments was passed {argumentsValues.Count}");
 
 			return Invoke(
-				argument1.ConvertValue(argumentsValues[0]), 
+				renderContext.Settings,
+				argument1.ConvertValue(argumentsValues[0]),
 				argument2.ConvertValue(argumentsValues[1]));
 		}
 	}

--- a/Engine/Quokka.Core/Functions/ScalarTemplateFunction`3.cs
+++ b/Engine/Quokka.Core/Functions/ScalarTemplateFunction`3.cs
@@ -15,6 +15,8 @@
 using System;
 using System.Collections.Generic;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	public abstract class ScalarTemplateFunction<TArgument1, TArgument2, TArgument3, TResult> : ScalarTemplateFunction
@@ -35,7 +37,7 @@ namespace Mindbox.Quokka
 			this.argument3 = argument3;
 		}
 
-		public abstract TResult Invoke(TArgument1 value1, TArgument2 value2, TArgument3 value3);
+		public abstract TResult Invoke(RenderSettings settings, TArgument1 value1, TArgument2 value2, TArgument3 value3);
 
 		internal override object GetScalarInvocationResult(
 			RenderContext renderContext,
@@ -45,6 +47,7 @@ namespace Mindbox.Quokka
 				throw new InvalidOperationException($"Function that expects 3 arguments was passed {argumentsValues.Count}");
 
 			return Invoke(
+				renderContext.Settings,
 				argument1.ConvertValue(argumentsValues[0]),
 				argument2.ConvertValue(argumentsValues[1]),
 				argument3.ConvertValue(argumentsValues[2]));

--- a/Engine/Quokka.Core/Functions/ScalarTemplateFunction`4.cs
+++ b/Engine/Quokka.Core/Functions/ScalarTemplateFunction`4.cs
@@ -15,6 +15,8 @@
 using System;
 using System.Collections.Generic;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	public abstract class ScalarTemplateFunction<TArgument1, TArgument2, TArgument3, TArgument4, TResult> : ScalarTemplateFunction
@@ -38,7 +40,7 @@ namespace Mindbox.Quokka
 			this.argument4 = argument4;
 		}
 
-		public abstract TResult Invoke(TArgument1 value1, TArgument2 value2, TArgument3 value3, TArgument4 value4);
+		public abstract TResult Invoke(RenderSettings settings, TArgument1 value1, TArgument2 value2, TArgument3 value3, TArgument4 value4);
 
 		internal override object GetScalarInvocationResult(
 			RenderContext renderContext,
@@ -48,6 +50,7 @@ namespace Mindbox.Quokka
 				throw new InvalidOperationException($"Function that expects 4 arguments was passed {argumentsValues.Count}");
 
 			return Invoke(
+				renderContext.Settings,
 				argument1.ConvertValue(argumentsValues[0]), 
 				argument2.ConvertValue(argumentsValues[1]), 
 				argument3.ConvertValue(argumentsValues[2]), 

--- a/Engine/Quokka.Core/Functions/Standard/AddDaysTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/AddDaysTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class AddDaysTemplateFunction : ScalarTemplateFunction<DateTime, decimal, DateTime>
@@ -26,7 +28,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override DateTime Invoke(DateTime date, decimal daysAmount)
+		public override DateTime Invoke(RenderSettings settings, DateTime date, decimal daysAmount)
 		{
 			return date.AddDays((double)daysAmount);
 		}

--- a/Engine/Quokka.Core/Functions/Standard/AppendFormsTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/AppendFormsTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class AppendFormsTemplateFunction : ScalarTemplateFunction<decimal, string, string, string, string>
@@ -28,7 +30,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(decimal quantity, string singularForm, string dualForm, string pluralForm)
+		public override string Invoke(RenderSettings settings, decimal quantity, string singularForm, string dualForm, string pluralForm)
 		{
 			var intQuantity = Convert.ToInt32(quantity);
 			return quantity + " " + LanguageUtility.GetQuantityForm(intQuantity, singularForm, dualForm, pluralForm);

--- a/Engine/Quokka.Core/Functions/Standard/CapitalizeAllWordsTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/CapitalizeAllWordsTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System.Globalization;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class CapitalizeAllWordsTemplateFunction : ScalarTemplateFunction<string, string>
@@ -23,7 +25,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string value)
+		public override string Invoke(RenderSettings settings, string value)
 		{
 			return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(value);
 		}

--- a/Engine/Quokka.Core/Functions/Standard/CapitalizeAllWordsTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/CapitalizeAllWordsTemplateFunction.cs
@@ -27,7 +27,7 @@ namespace Mindbox.Quokka
 
 		public override string Invoke(RenderSettings settings, string value)
 		{
-			return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(value);
+			return settings.CultureInfo.TextInfo.ToTitleCase(value);
 		}
 	}
 }

--- a/Engine/Quokka.Core/Functions/Standard/CapitalizeTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/CapitalizeTemplateFunction.cs
@@ -15,6 +15,8 @@
 using System;
 using System.Linq;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class CapitalizeTemplateFunction : ScalarTemplateFunction<string, string>
@@ -24,7 +26,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string value)
+		public override string Invoke(RenderSettings settings, string value)
 		{
 			if (value == null)
 				throw new ArgumentNullException(nameof(value));

--- a/Engine/Quokka.Core/Functions/Standard/CeilingTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/CeilingTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	public class CeilingTemplateFunction : ScalarTemplateFunction<decimal, decimal>
@@ -24,7 +26,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override decimal Invoke(decimal value)
+		public override decimal Invoke(RenderSettings settings, decimal value)
 		{
 			return Math.Ceiling(value);
 		}

--- a/Engine/Quokka.Core/Functions/Standard/FloorTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/FloorTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	public class FloorTemplateFunction : ScalarTemplateFunction<decimal, decimal>
@@ -24,7 +26,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override decimal Invoke(decimal value)
+		public override decimal Invoke(RenderSettings settings, decimal value)
 		{
 			return Math.Floor(value);
 		}

--- a/Engine/Quokka.Core/Functions/Standard/FormatDateTimeTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/FormatDateTimeTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class FormatDateTimeTemplateFunction : ScalarTemplateFunction<DateTime, string, string>
@@ -26,9 +28,9 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(DateTime argument1, string argument2)
+		public override string Invoke(RenderSettings settings, DateTime argument1, string argument2)
 		{
-			return argument1.ToString(argument2);
+			return argument1.ToString(argument2, settings.CultureInfo);
 		}
 
 		private static ArgumentValueValidationResult ValidateFormat(string format)

--- a/Engine/Quokka.Core/Functions/Standard/FormatDecimalTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/FormatDecimalTemplateFunction.cs
@@ -15,6 +15,8 @@
 using System;
 using System.Globalization;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class FormatDecimalTemplateFunction : ScalarTemplateFunction<decimal, string, string>
@@ -27,9 +29,9 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(decimal argument1, string argument2)
+		public override string Invoke(RenderSettings settings, decimal argument1, string argument2)
 		{
-			return argument1.ToString(argument2, CultureInfo.CurrentCulture);
+			return argument1.ToString(argument2, settings.CultureInfo);
 		}
 
 		private static ArgumentValueValidationResult ValidateFormat(string format)

--- a/Engine/Quokka.Core/Functions/Standard/FormatTimeTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/FormatTimeTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class FormatTimeTemplateFunction : ScalarTemplateFunction<TimeSpan, string, string>
@@ -26,9 +28,9 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(TimeSpan argument1, string argument2)
+		public override string Invoke(RenderSettings settings, TimeSpan argument1, string argument2)
 		{
-			return argument1.ToString(argument2);
+			return argument1.ToString(argument2, settings.CultureInfo);
 		}
 
 		private static ArgumentValueValidationResult ValidateFormat(string format)

--- a/Engine/Quokka.Core/Functions/Standard/FormsTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/FormsTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class FormsTemplateFunction : ScalarTemplateFunction<decimal, string, string, string, string>
@@ -28,7 +30,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(decimal quantity, string singularForm, string dualForm, string pluralForm)
+		public override string Invoke(RenderSettings settings, decimal quantity, string singularForm, string dualForm, string pluralForm)
 		{
 			var intQuantity = Convert.ToInt32(quantity);
 			return LanguageUtility.GetQuantityForm(intQuantity, singularForm, dualForm, pluralForm);

--- a/Engine/Quokka.Core/Functions/Standard/GetDayTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/GetDayTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
     internal class GetDayTemplateFunction : ScalarTemplateFunction<DateTime, int>
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka
         {
         }
 
-        public override int Invoke(DateTime dateTime)
+        public override int Invoke(RenderSettings settings, DateTime dateTime)
         {
             return dateTime.Day;
         }

--- a/Engine/Quokka.Core/Functions/Standard/GetMonthTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/GetMonthTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
     internal class GetMonthTemplateFunction : ScalarTemplateFunction<DateTime, int>
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka
         {
         }
 
-        public override int Invoke(DateTime dateTime)
+        public override int Invoke(RenderSettings settings, DateTime dateTime)
         {
             return dateTime.Month;
         }

--- a/Engine/Quokka.Core/Functions/Standard/GetYearTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/GetYearTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
     internal class GetYearTemplateFunction : ScalarTemplateFunction<DateTime, int>
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka
         {
         }
 
-        public override int Invoke(DateTime dateTime)
+        public override int Invoke(RenderSettings settings, DateTime dateTime)
         {
             return dateTime.Year;
         }

--- a/Engine/Quokka.Core/Functions/Standard/Hash/HashFunctionBase.cs
+++ b/Engine/Quokka.Core/Functions/Standard/Hash/HashFunctionBase.cs
@@ -16,6 +16,8 @@ using System;
 using System.Security.Cryptography;
 using System.Text;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal abstract class HashFunctionBase : ScalarTemplateFunction<string, string>
@@ -29,7 +31,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string argument1)
+		public override string Invoke(RenderSettings settings, string argument1)
 		{
 			return GetHashString(argument1);
 		}

--- a/Engine/Quokka.Core/Functions/Standard/IfTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/IfTemplateFunction.cs
@@ -12,6 +12,8 @@
 // // See the License for the specific language governing permissions and
 // // limitations under the License.
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class IfTemplateFunction : ScalarTemplateFunction<bool, string, string, string>
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(bool argument1, string argument2, string argument3)
+		public override string Invoke(RenderSettings settings, bool argument1, string argument2, string argument3)
 		{
 			return argument1 ? argument2 : argument3;
 		}

--- a/Engine/Quokka.Core/Functions/Standard/LengthTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/LengthTemplateFunction.cs
@@ -18,6 +18,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
     internal class LengthTemplateFunction : ScalarTemplateFunction<string, int>
@@ -27,7 +29,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override int Invoke(string value)
+		public override int Invoke(RenderSettings settings, string value)
 		{
 			return value.Length;
 		}

--- a/Engine/Quokka.Core/Functions/Standard/ReplaceIfEmptyTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/ReplaceIfEmptyTemplateFunction.cs
@@ -12,6 +12,8 @@
 // // See the License for the specific language governing permissions and
 // // limitations under the License.
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class ReplaceIfEmptyTemplateFunction : ScalarTemplateFunction<string, string, string>
@@ -24,7 +26,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string argument1, string argument2)
+		public override string Invoke(RenderSettings settings, string argument1, string argument2)
 		{
 			return !string.IsNullOrWhiteSpace(argument1) ? argument1 : argument2;
 		}

--- a/Engine/Quokka.Core/Functions/Standard/SubstringTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/SubstringTemplateFunction.cs
@@ -12,6 +12,8 @@
 // // See the License for the specific language governing permissions and
 // // limitations under the License.
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	public class SubstringTemplateFunction : ScalarTemplateFunction<string, int, string>
@@ -26,7 +28,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string value, int startIndex)
+		public override string Invoke(RenderSettings settings, string value, int startIndex)
 		{
 			// in templates indexing from 1 is assumed
 			return value.Substring(startIndex - 1);

--- a/Engine/Quokka.Core/Functions/Standard/SubstringWithLengthTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/SubstringWithLengthTemplateFunction.cs
@@ -12,6 +12,8 @@
 // // See the License for the specific language governing permissions and
 // // limitations under the License.
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	public class SubstringWithLengthTemplateFunction : ScalarTemplateFunction<string, int, int, string>
@@ -30,7 +32,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string value, int startIndex, int length)
+		public override string Invoke(RenderSettings settings, string value, int startIndex, int length)
 		{
 			// in templates indexing from 1 is assumed
 			return value.Substring(startIndex - 1, length);

--- a/Engine/Quokka.Core/Functions/Standard/ToBase64TemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/ToBase64TemplateFunction.cs
@@ -15,6 +15,8 @@
 using System;
 using System.Text;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class ToBase64TemplateFunction : ScalarTemplateFunction<string, string>
@@ -26,7 +28,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string argument1)
+		public override string Invoke(RenderSettings settings, string argument1)
 		{
 			return Convert.ToBase64String(Encoding.UTF8.GetBytes(argument1));
 		}

--- a/Engine/Quokka.Core/Functions/Standard/ToHexTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/ToHexTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System.Text;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class ToHexTemplateFunction : ScalarTemplateFunction<string, string>
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string argument1)
+		public override string Invoke(RenderSettings settings, string argument1)
 		{
 			return ByteUtility.ToHexString(Encoding.UTF8.GetBytes(argument1));
 		}

--- a/Engine/Quokka.Core/Functions/Standard/ToLowerTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/ToLowerTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System.Globalization;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class ToLowerTemplateFunction : ScalarTemplateFunction<string, string>
@@ -25,9 +27,9 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string argument1)
+		public override string Invoke(RenderSettings settings, string argument1)
 		{
-			return argument1.ToLower(CultureInfo.CurrentCulture);
+			return argument1.ToLower(settings.CultureInfo);
 		}
 	}
 }

--- a/Engine/Quokka.Core/Functions/Standard/ToUpperTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/ToUpperTemplateFunction.cs
@@ -14,6 +14,8 @@
 
 using System.Globalization;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class ToUpperTemplateFunction : ScalarTemplateFunction<string, string>
@@ -25,9 +27,9 @@ namespace Mindbox.Quokka
 		{
 		}
 
-		public override string Invoke(string argument1)
+		public override string Invoke(RenderSettings settings, string argument1)
 		{
-			return argument1.ToUpper(CultureInfo.CurrentCulture);
+			return argument1.ToUpper(settings.CultureInfo);
 		}
 	}
 }

--- a/Engine/Quokka.Core/Functions/Standard/TruncateTemplateFunction.cs
+++ b/Engine/Quokka.Core/Functions/Standard/TruncateTemplateFunction.cs
@@ -16,6 +16,8 @@ using System;
 using System.Linq;
 using System.Text;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
     public class TruncateTemplateFunction : ScalarTemplateFunction<string, decimal, string>
@@ -35,7 +37,7 @@ namespace Mindbox.Quokka
                 : new ArgumentValueValidationResult(false, "Нельзя ограничить строку менее чем пятью символами");
         }
 
-        public override string Invoke(string inputString, decimal allowedLength)
+        public override string Invoke(RenderSettings settings, string inputString, decimal allowedLength)
         {
             var targetLength = Convert.ToInt32(allowedLength);
             if (inputString.Length <= targetLength)

--- a/Engine/Quokka.Core/Html/HtmlRenderContext.cs
+++ b/Engine/Quokka.Core/Html/HtmlRenderContext.cs
@@ -15,6 +15,8 @@
 using System;
 using System.IO;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Html
 {
 	internal class HtmlRenderContext : RenderContext
@@ -32,8 +34,9 @@ namespace Mindbox.Quokka.Html
 			FunctionRegistry functions, 
 			Func<Guid, string, string> redirectLinkProcessor,
 			string identificationCode,
+			RenderSettings settings,
 			ICallContextContainer callContextContainer)
-			: this(variableScope, functions, redirectLinkProcessor, identificationCode, callContextContainer, null)
+			: this(variableScope, functions, redirectLinkProcessor, identificationCode, settings, callContextContainer, null)
 		{
 			// empty
 		}
@@ -43,9 +46,10 @@ namespace Mindbox.Quokka.Html
 			FunctionRegistry functions, 
 			Func<Guid, string, string> redirectLinkProcessor,
 			string identificationCode,
+			RenderSettings settings,
 			ICallContextContainer callContextContainer,
 			HtmlRenderContext parentRenderContext)
-			: base(variableScope, functions, callContextContainer)
+			: base(variableScope, functions, settings, callContextContainer)
 		{
 			RedirectLinkProcessor = redirectLinkProcessor;
 			IdentificationCode = identificationCode;
@@ -55,7 +59,7 @@ namespace Mindbox.Quokka.Html
 		public override RenderContext CreateInnerContext(RuntimeVariableScope variableScope)
 		{
 			return new HtmlRenderContext(
-				variableScope, Functions, RedirectLinkProcessor, IdentificationCode, CallContextContainer, this)
+				variableScope, Functions, RedirectLinkProcessor, IdentificationCode, Settings, CallContextContainer, this)
 			{
 				HasIdentificationCodeBeenRendered = HasIdentificationCodeBeenRendered
 			};

--- a/Engine/Quokka.Core/Html/HtmlTemplate.cs
+++ b/Engine/Quokka.Core/Html/HtmlTemplate.cs
@@ -86,6 +86,16 @@ namespace Mindbox.Quokka.Html
 			string identificationCode = null,
 			ICallContextContainer callContextContainer = null)
 		{
+			return Render(model, redirectLinkProcessor, RenderSettings.Default, identificationCode, callContextContainer);
+		}
+
+		public string Render(
+			ICompositeModelValue model,
+			Func<Guid, string, string> redirectLinkProcessor,
+			RenderSettings settings,
+			string identificationCode = null,
+			ICallContextContainer callContextContainer = null)
+		{
 			if (model == null)
 				throw new ArgumentNullException(nameof(model));
 
@@ -102,6 +112,7 @@ namespace Mindbox.Quokka.Html
 						functionRegistry,
 						redirectLinkProcessor,
 						identificationCode,
+						settings,
 						effectiveCallContextContainer));
 			}
 
@@ -131,6 +142,17 @@ namespace Mindbox.Quokka.Html
 			string identificationCode = null,
 			ICallContextContainer callContextContainer = null)
 		{
+			Render(textWriter, model, redirectLinkProcessor, RenderSettings.Default, identificationCode, callContextContainer);
+		}
+
+		public void Render(
+			TextWriter textWriter,
+			ICompositeModelValue model,
+			Func<Guid, string, string> redirectLinkProcessor,
+			RenderSettings settings,
+			string identificationCode = null,
+			ICallContextContainer callContextContainer = null)
+		{
 			if (model == null)
 				throw new ArgumentNullException(nameof(model));
 
@@ -144,6 +166,7 @@ namespace Mindbox.Quokka.Html
 					functionRegistry,
 					redirectLinkProcessor,
 					identificationCode,
+					settings,
 					effectiveCallContextContainer));
 		}
 	}

--- a/Engine/Quokka.Core/Html/HtmlTemplate.cs
+++ b/Engine/Quokka.Core/Html/HtmlTemplate.cs
@@ -18,6 +18,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Html
 {
 	internal class HtmlTemplate : Template, IHtmlTemplate
@@ -56,7 +58,7 @@ namespace Mindbox.Quokka.Html
 			return htmlContext.GetReferences();
 		}
 
-		public override string Render(ICompositeModelValue model, ICallContextContainer callContextContainer = null)
+		public override string Render(ICompositeModelValue model, RenderSettings settings, ICallContextContainer callContextContainer = null)
 		{
 			var effectiveCallContextContainer = callContextContainer ?? CallContextContainer.Empty;
 
@@ -71,6 +73,7 @@ namespace Mindbox.Quokka.Html
 						functionRegistry,
 						null,
 						null,
+						settings,
 						effectiveCallContextContainer));
 			}
 
@@ -105,7 +108,7 @@ namespace Mindbox.Quokka.Html
 			return stringBuilder.ToString();
 		}
 
-		public override void Render(TextWriter textWriter, ICompositeModelValue model, ICallContextContainer callContextContainer = null)
+		public override void Render(TextWriter textWriter, ICompositeModelValue model, RenderSettings settings, ICallContextContainer callContextContainer = null)
 		{
 			var effectiveCallContextContainer = callContextContainer ?? CallContextContainer.Empty;
 
@@ -117,6 +120,7 @@ namespace Mindbox.Quokka.Html
 						functionRegistry,
 						null,
 						null,
+						settings,
 						effectiveCallContextContainer));
 		}
 

--- a/Engine/Quokka.Core/Rendering/RenderContext.cs
+++ b/Engine/Quokka.Core/Rendering/RenderContext.cs
@@ -15,6 +15,8 @@
 using System;
 using System.IO;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka
 {
 	internal class RenderContext
@@ -23,8 +25,11 @@ namespace Mindbox.Quokka
 		public FunctionRegistry Functions { get; }
 		public ICallContextContainer CallContextContainer { get; }
 
+		public RenderSettings Settings { get; }
+
 		public RenderContext(
-			RuntimeVariableScope variableScope, FunctionRegistry functions, ICallContextContainer callContextContainer)
+			RuntimeVariableScope variableScope, FunctionRegistry functions, RenderSettings settings,
+			ICallContextContainer callContextContainer)
 		{
 			if (callContextContainer == null) 
 				throw new ArgumentNullException(nameof(callContextContainer));
@@ -32,11 +37,12 @@ namespace Mindbox.Quokka
 			VariableScope = variableScope;
 			Functions = functions;
 			CallContextContainer = callContextContainer;
+			Settings = settings;
 		}
 
 		public virtual RenderContext CreateInnerContext(RuntimeVariableScope variableScope)
 		{
-			return new RenderContext(variableScope, Functions, CallContextContainer);
+			return new RenderContext(variableScope, Functions, Settings, CallContextContainer);
 		}
 
 		public virtual void OnRenderingEnd(TextWriter resultWriter)

--- a/Engine/Quokka.Core/Rendering/RenderContext.cs
+++ b/Engine/Quokka.Core/Rendering/RenderContext.cs
@@ -24,7 +24,6 @@ namespace Mindbox.Quokka
 		public RuntimeVariableScope VariableScope { get; }
 		public FunctionRegistry Functions { get; }
 		public ICallContextContainer CallContextContainer { get; }
-
 		public RenderSettings Settings { get; }
 
 		public RenderContext(

--- a/Engine/Quokka.Core/Template.cs
+++ b/Engine/Quokka.Core/Template.cs
@@ -20,6 +20,7 @@ using System.Text;
 
 using Antlr4.Runtime;
 
+using Mindbox.Quokka.Abstractions;
 using Mindbox.Quokka.Generated;
 
 namespace Mindbox.Quokka
@@ -115,7 +116,12 @@ namespace Mindbox.Quokka
 			return requiredModelDefinition;
 		}
 
-		public virtual string Render(ICompositeModelValue model, ICallContextContainer callContextContainer = null)
+		public string Render(ICompositeModelValue model, ICallContextContainer callContextContainer = null)
+		{
+			return Render(model, RenderSettings.Default, callContextContainer);
+		}
+
+		public virtual string Render(ICompositeModelValue model, RenderSettings settings, ICallContextContainer callContextContainer = null)
 		{
 			if (model == null)
 				throw new ArgumentNullException(nameof(model));
@@ -133,13 +139,23 @@ namespace Mindbox.Quokka
 					(scope, contextFunctionRegistry) => new RenderContext(
 						scope,
 						contextFunctionRegistry,
+						settings,
 						effectiveCallContextContainer));
 			}
 
 			return stringBuilder.ToString();
 		}
 
-		public virtual void Render(TextWriter textWriter, ICompositeModelValue model, ICallContextContainer callContextContainer = null)
+		public void Render(TextWriter textWriter, ICompositeModelValue model, ICallContextContainer callContextContainer = null)
+		{
+			Render(textWriter, model, RenderSettings.Default, callContextContainer);
+		}
+
+		public virtual void Render(
+			TextWriter textWriter,
+			ICompositeModelValue model,
+			RenderSettings settings,
+			ICallContextContainer callContextContainer = null)
 		{
 			if (textWriter == null)
 				throw new ArgumentNullException(nameof(textWriter));
@@ -154,7 +170,7 @@ namespace Mindbox.Quokka
 				textWriter,
 				model,
 				(scope, contextFunctionRegistry) => new RenderContext(
-					scope, contextFunctionRegistry, effectiveCallContextContainer));
+					scope, contextFunctionRegistry, settings, effectiveCallContextContainer));
 		}
 
 		protected void DoRender(

--- a/Engine/Quokka.Tests/Creating/StaticTemplateErrorsInFunctionsTests.cs
+++ b/Engine/Quokka.Tests/Creating/StaticTemplateErrorsInFunctionsTests.cs
@@ -16,6 +16,8 @@ using System.Collections.Generic;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -129,7 +131,7 @@ namespace Mindbox.Quokka.Tests
 			{
 			}
 
-			public override int Invoke(int value)
+			public override int Invoke(RenderSettings settings, int value)
 			{
 				return value;
 			}
@@ -144,7 +146,7 @@ namespace Mindbox.Quokka.Tests
 			{
 			}
 
-			public override decimal Invoke(decimal value)
+			public override decimal Invoke(RenderSettings settings, decimal value)
 			{
 				return value;
 			}

--- a/Engine/Quokka.Tests/Creating/TemplateFactoryTests.cs
+++ b/Engine/Quokka.Tests/Creating/TemplateFactoryTests.cs
@@ -17,6 +17,8 @@ using System.Linq;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -84,7 +86,7 @@ namespace Mindbox.Quokka.Tests
 			{
 			}
 
-			public override string Invoke(string argument)
+			public override string Invoke(RenderSettings settings, string argument)
 			{
 				return "Test";
 			}

--- a/Engine/Quokka.Tests/Functions/Md5HashFunctionTests.cs
+++ b/Engine/Quokka.Tests/Functions/Md5HashFunctionTests.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka.Tests
 			var email = "strange@email.com";
 			var md5 = new Md5HashFunction();
 
-			var hash = md5.Invoke(email);
+			var hash = md5.Invoke(RenderSettings.Default, email);
 			Assert.AreEqual("152F2DD5F1F056FC761717EA5965828C", hash);
 		}
 	}

--- a/Engine/Quokka.Tests/Functions/Sha1HashFunctionTests.cs
+++ b/Engine/Quokka.Tests/Functions/Sha1HashFunctionTests.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka.Tests
 			var email = "strange@email.com";
 			var sha1 = new Sha1HashFunction();
 
-			var hash = sha1.Invoke(email);
+			var hash = sha1.Invoke(RenderSettings.Default, email);
 			Assert.AreEqual("4AD63D3592358CE97B2FC7F6C570C73944B278B5", hash);
 		}
 	}

--- a/Engine/Quokka.Tests/Functions/Sha256HashFunctionTests.cs
+++ b/Engine/Quokka.Tests/Functions/Sha256HashFunctionTests.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka.Tests
 			var email = "strange@email.com";
 			var sha256 = new Sha256HashFunction();
 
-			var hash = sha256.Invoke(email);
+			var hash = sha256.Invoke(RenderSettings.Default, email);
 			Assert.AreEqual("44B59FF2773CD61533A1CEBCBF473DB0D7960AC843AA6B346E7FB86E84827B68", hash);
 		}
 	}

--- a/Engine/Quokka.Tests/Functions/Sha512HashFunctionTests.cs
+++ b/Engine/Quokka.Tests/Functions/Sha512HashFunctionTests.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka.Tests
 			var email = "strange@email.com";
 			var sha256 = new Sha512HashFunction();
 
-			var hash = sha256.Invoke(email);
+			var hash = sha256.Invoke(RenderSettings.Default, email);
 			Assert.AreEqual(
 				"36A612F958405DB0EB1D456BE3C25867CC9895D1A10696205F7655728E94229362F0511AF4029692D72F1C421A5213F5AFC20B1CAF5271CFB6D1018624B17CE7",
 				hash);

--- a/Engine/Quokka.Tests/Functions/ToBase64TemplateFunctionTests.cs
+++ b/Engine/Quokka.Tests/Functions/ToBase64TemplateFunctionTests.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka.Tests
 			var someString = "just-test-string";
 			var toBase64 = new ToBase64TemplateFunction();
 
-			var base64Value = toBase64.Invoke(someString);
+			var base64Value = toBase64.Invoke(RenderSettings.Default, someString);
 			Assert.AreEqual(
 				"anVzdC10ZXN0LXN0cmluZw==",
 				base64Value);

--- a/Engine/Quokka.Tests/Functions/ToHexTemplateFunctionTests.cs
+++ b/Engine/Quokka.Tests/Functions/ToHexTemplateFunctionTests.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -25,7 +27,7 @@ namespace Mindbox.Quokka.Tests
 			var email = "https://strange@email.com?some=parame&other#things";
 			var hexValue = new ToHexTemplateFunction();
 
-			var hash = hexValue.Invoke(email);
+			var hash = hexValue.Invoke(RenderSettings.Default, email);
 			Assert.AreEqual(
 				"68747470733A2F2F737472616E676540656D61696C2E636F6D3F736F6D653D706172616D65266F74686572237468696E6773",
 				hash);

--- a/Engine/Quokka.Tests/ModelValidation/FunctionArgumentValidationTests.cs
+++ b/Engine/Quokka.Tests/ModelValidation/FunctionArgumentValidationTests.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -34,7 +36,7 @@ namespace Mindbox.Quokka.Tests
 					: new ArgumentValueValidationResult(false, "Test");
 			}
 
-			public override decimal Invoke(decimal value)
+			public override decimal Invoke(RenderSettings settings, decimal value)
 			{
 				return value;
 			}

--- a/Engine/Quokka.Tests/ParameterDiscovery/ModelDiscoveryMethodsBasicTests.cs
+++ b/Engine/Quokka.Tests/ParameterDiscovery/ModelDiscoveryMethodsBasicTests.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
 using Mindbox.Quokka.Tests;
 
 namespace Mindbox.Quokka
@@ -431,7 +432,7 @@ namespace Mindbox.Quokka
 		    {
 		    }
 
-		    public override int Invoke(int value)
+		    public override int Invoke(RenderSettings settings, int value)
 		    {
 			    return value;
 		    }

--- a/Engine/Quokka.Tests/Rendering/RenderBaseScalarFunctionTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderBaseScalarFunctionTests.cs
@@ -189,7 +189,7 @@ namespace Mindbox.Quokka.Tests
 				this.callBack = callBack;
 			}
 
-			public override string Invoke(string value1, string value2, string value3, string value4)
+			public override string Invoke(RenderSettings settings, string value1, string value2, string value3, string value4)
 			{
 				callBack();
 				return $"[{value1}][{value2}][{value3}][{value4}]";

--- a/Engine/Quokka.Tests/Rendering/RenderBaseScalarFunctionTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderBaseScalarFunctionTests.cs
@@ -167,7 +167,7 @@ namespace Mindbox.Quokka.Tests
 				this.callBack = callBack;
 			}
 
-			public override string Invoke(string value1, string value2, string value3)
+			public override string Invoke(RenderSettings settings, string value1, string value2, string value3)
 			{
 				callBack();
 				return $"[{value1}][{value2}][{value3}]";

--- a/Engine/Quokka.Tests/Rendering/RenderBaseScalarFunctionTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderBaseScalarFunctionTests.cs
@@ -126,7 +126,7 @@ namespace Mindbox.Quokka.Tests
 				this.callBack = callBack;
 			}
 
-			public override string Invoke(string value1)
+			public override string Invoke(RenderSettings settings, string value1)
 			{
 				callBack();
 				return $"[{value1}]";

--- a/Engine/Quokka.Tests/Rendering/RenderBaseScalarFunctionTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderBaseScalarFunctionTests.cs
@@ -15,6 +15,8 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -144,7 +146,7 @@ namespace Mindbox.Quokka.Tests
 				this.callBack = callBack;
 			}
 
-			public override string Invoke(string value1, string value2)
+			public override string Invoke(RenderSettings settings, string value1, string value2)
 			{
 				callBack();
 				return $"[{value1}][{value2}]";

--- a/Engine/Quokka.Tests/Rendering/RenderIfBlockNullComparisonTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderIfBlockNullComparisonTests.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -356,7 +358,7 @@ namespace Mindbox.Quokka.Tests
 			{
 			}
 
-			public override string Invoke(bool value)
+			public override string Invoke(RenderSettings settings, bool value)
 			{
 				return value ? null : "";
 			}

--- a/Engine/Quokka.Tests/Settings/RenderSettingsCultureInfoTests.cs
+++ b/Engine/Quokka.Tests/Settings/RenderSettingsCultureInfoTests.cs
@@ -104,4 +104,20 @@ public sealed class RenderSettingsCultureInfoTests
         
         Assert.AreEqual(expectedFormat, result);
     }
+    
+    [TestMethod]
+    [DataRow("Карл у Клары украл кораллы", "ru-RU")]
+    [DataRow("Clara stole Carl's Clarinet", "en-US")]
+    public void CapitalizeAllWordsTemplateFunction_ReturnsLocalizedResult(string input, string locale)
+    {
+        var settings = new RenderSettings { CultureInfo = new CultureInfo(locale) };
+        var expectedFormat = settings.CultureInfo.TextInfo.ToTitleCase(input);
+        
+        var template = new Template("${CapitalizeAllWords(Input)}");
+        var result = template.Render(
+            new CompositeModelValue(new ModelField("Input", input)),
+            settings);
+        
+        Assert.AreEqual(expectedFormat, result);
+    }
 }

--- a/Engine/Quokka.Tests/Settings/RenderSettingsCultureInfoTests.cs
+++ b/Engine/Quokka.Tests/Settings/RenderSettingsCultureInfoTests.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// // Copyright 2022 Mindbox Ltd
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+using System;
 using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Mindbox.Quokka.Abstractions;

--- a/Engine/Quokka.Tests/Settings/RenderSettingsCultureInfoTests.cs
+++ b/Engine/Quokka.Tests/Settings/RenderSettingsCultureInfoTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mindbox.Quokka.Abstractions;
+
+namespace Mindbox.Quokka.Tests;
+
+[TestClass]
+public sealed class RenderSettingsCultureInfoTests
+{
+    [TestMethod]
+    [DataRow("en-US")]
+    [DataRow("ru-RU")]
+    public void FormatDateTimeTemplateFunction_ReturnsLocalizedResult(string locale)
+    {
+        var dt = DateTime.UtcNow;
+        var settings = new RenderSettings { CultureInfo = new CultureInfo(locale) };
+        var expectedFormat = dt.ToString("MMMM", settings.CultureInfo);
+        
+        var template = new Template("${FormatDateTime(Date, 'MMMM')}");
+        var result = template.Render(
+            new CompositeModelValue(new ModelField("Date", dt)),
+            settings);
+        
+        Assert.AreEqual(expectedFormat, result);
+    }
+    
+    [TestMethod]
+    [DataRow("en-US")]
+    [DataRow("ru-RU")]
+    public void FormatTimeTemplateFunction_ReturnsLocalizedResult(string locale)
+    {
+        var dt = DateTime.UtcNow.TimeOfDay;
+        var settings = new RenderSettings { CultureInfo = new CultureInfo(locale) };
+        var expectedFormat = dt.ToString("g", settings.CultureInfo);
+        
+        var template = new Template("${FormatTime(Date, 'g')}");
+        var result = template.Render(
+            new CompositeModelValue(new ModelField("Date", dt)),
+            settings);
+        
+        Assert.AreEqual(expectedFormat, result);
+    }
+    
+    [TestMethod]
+    [DataRow("Карл у Клары украл кораллы", "ru-RU")]
+    [DataRow("Clara stole Carl's Clarinet", "en-US")]
+    public void ToUpperTemplateFunction_ReturnsLocalizedResult(string input, string locale)
+    {
+        var settings = new RenderSettings { CultureInfo = new CultureInfo(locale) };
+        var expectedFormat = input.ToUpper(settings.CultureInfo);
+        
+        var template = new Template("${ToUpper(Input)}");
+        var result = template.Render(
+            new CompositeModelValue(new ModelField("Input", input)),
+            settings);
+        
+        Assert.AreEqual(expectedFormat, result);
+    }
+    
+    [TestMethod]
+    [DataRow("Карл у Клары украл кораллы", "ru-RU")]
+    [DataRow("Clara stole Carl's Clarinet", "en-US")]
+    public void ToLowerTemplateFunction_ReturnsLocalizedResult(string input, string locale)
+    {
+        var settings = new RenderSettings { CultureInfo = new CultureInfo(locale) };
+        var expectedFormat = input.ToLower(settings.CultureInfo);
+        
+        var template = new Template("${ToLower(Input)}");
+        var result = template.Render(
+            new CompositeModelValue(new ModelField("Input", input)),
+            settings);
+        
+        Assert.AreEqual(expectedFormat, result);
+    }
+    
+    [TestMethod]
+    [DataRow("en-US")]
+    [DataRow("ru-RU")]
+    public void FormatDecimalTemplateFunction_ReturnsLocalizedResult(string locale)
+    {
+        var input = (decimal)Random.Shared.NextDouble() * 1000;
+        var settings = new RenderSettings { CultureInfo = new CultureInfo(locale) };
+        var expectedFormat = input.ToString("C", settings.CultureInfo);
+        
+        var template = new Template("${FormatDecimal(Input, 'C')}");
+        var result = template.Render(
+            new CompositeModelValue(new ModelField("Input", input)),
+            settings);
+        
+        Assert.AreEqual(expectedFormat, result);
+    }
+}


### PR DESCRIPTION
- https://github.com/mindbox-cloud/issues-mailings/issues/1195

### Поддержка выбранной культуры в процессе рендеринга темплейта.

- Добавлены настройки рендеринга `RenderSettings`. В настройки добавлена информация по культуре `CultureInfo`.

- Добавлены новые методы в интерфейсы `ITemplate` и `IHtmlTemplate`, чтобы использовать `RenderSettings`

- Переопределены все методы ScalarTemplateFunction. Теперь все они имеют доступ к `RenderSettings`

- Доработаны все функции форматирования. Теперь все они используют культуру из `RenderSettings`

- Добавлены культурные тесты