### PR TITLE
Report the reason, the expression and the location of runtime render errors

### DIFF
--- a/Engine/Directory.Build.props
+++ b/Engine/Directory.Build.props
@@ -16,6 +16,6 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <VersionPrefix>8.3.0</VersionPrefix>
+        <VersionPrefix>8.4.0</VersionPrefix>
     </PropertyGroup>
 </Project>

--- a/Engine/Mindbox.Quokka.Abstractions/Errors/Location.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Errors/Location.cs
@@ -25,7 +25,7 @@ namespace Mindbox.Quokka
 		public int Line { get; }
 
 		/// <summary>
-		/// Column index (1-based)
+		/// Column index (0-based)
 		/// </summary>
 		public int Column { get; }
 

--- a/Engine/Mindbox.Quokka.Abstractions/Exceptions/ArithmeticErrorReason.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Exceptions/ArithmeticErrorReason.cs
@@ -1,0 +1,38 @@
+﻿// // Copyright 2022 Mindbox Ltd
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+namespace Mindbox.Quokka
+{
+	/// <summary>
+	/// The reason why an arithmetic operation result could not be evaluated.
+	/// Meant to be used by the calling code to build its own message, e.g. a localized one.
+	/// </summary>
+	public enum ArithmeticErrorReason
+	{
+		/// <summary>
+		/// The result is infinite. Within a template this is only reachable by dividing by zero.
+		/// </summary>
+		DivisionByZero,
+
+		/// <summary>
+		/// The result is not a number, e.g. when zero is divided by zero.
+		/// </summary>
+		NotANumber,
+
+		/// <summary>
+		/// The result is a finite number, but it is too large to be represented as a template value.
+		/// </summary>
+		ResultOutOfRange
+	}
+}

--- a/Engine/Mindbox.Quokka.Abstractions/Exceptions/ArithmeticErrorReason.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Exceptions/ArithmeticErrorReason.cs
@@ -21,7 +21,8 @@ namespace Mindbox.Quokka
 	public enum ArithmeticErrorReason
 	{
 		/// <summary>
-		/// The result is infinite. Within a template this is only reachable by dividing by zero.
+		/// The result is infinite. Within a template this practically always means a division by zero;
+		/// an overflow of intermediate values to infinity is also reported this way.
 		/// </summary>
 		DivisionByZero,
 

--- a/Engine/Mindbox.Quokka.Abstractions/Exceptions/ArithmeticOperationException.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Exceptions/ArithmeticOperationException.cs
@@ -1,0 +1,93 @@
+﻿// // Copyright 2022 Mindbox Ltd
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+using System;
+
+namespace Mindbox.Quokka
+{
+	/// <summary>
+	/// This exception occurs when an arithmetic operation within a template produces a result
+	/// which can't be used as a template value: an infinite one, a not-a-number one or an out of range one.
+	/// </summary>
+	[Serializable]
+	public class ArithmeticOperationException : UnrenderableTemplateModelException
+	{
+		/// <summary>
+		/// The error text without the reason, the expression and the location appended to it.
+		/// </summary>
+		public const string ErrorText = "Arithmetic operation result could not be evaluated";
+
+		/// <summary>
+		/// The reason the result could not be evaluated.
+		/// </summary>
+		public ArithmeticErrorReason Reason { get; }
+
+		/// <summary>
+		/// The source text of the failed expression as it is written in the template,
+		/// e.g. "cart.total / cart.itemCount". <c>Null</c> if the text can't be restored.
+		/// </summary>
+		public string Expression { get; }
+
+		public ArithmeticOperationException(
+			ArithmeticErrorReason reason,
+			string expression,
+			Location location,
+			Exception inner)
+			: base(BuildMessage(reason, expression, location), inner, location)
+		{
+			Reason = reason;
+			Expression = expression;
+
+			Data[QuokkaExceptionData.ErrorText] = ErrorText;
+			Data[QuokkaExceptionData.Reason] = reason.ToString();
+
+			if (expression != null)
+				Data[QuokkaExceptionData.Expression] = expression;
+		}
+
+		/// <summary>
+		/// The reason in the same wording the exception message uses.
+		/// </summary>
+		public static string GetReasonText(ArithmeticErrorReason reason)
+		{
+			switch (reason)
+			{
+				case ArithmeticErrorReason.DivisionByZero:
+					return "division by zero";
+
+				case ArithmeticErrorReason.NotANumber:
+					return "the result is not a number";
+
+				case ArithmeticErrorReason.ResultOutOfRange:
+					return "the result is out of the supported number range";
+
+				default:
+					throw new ArgumentOutOfRangeException(nameof(reason), reason, null);
+			}
+		}
+
+		private static string BuildMessage(ArithmeticErrorReason reason, string expression, Location location)
+		{
+			var message = $"{ErrorText}: {GetReasonText(reason)}";
+
+			if (!string.IsNullOrWhiteSpace(expression))
+				message += $" in \"{expression}\"";
+
+			if (location != null)
+				message += $" at {location}";
+
+			return message;
+		}
+	}
+}

--- a/Engine/Mindbox.Quokka.Abstractions/Exceptions/ArithmeticOperationException.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Exceptions/ArithmeticOperationException.cs
@@ -33,27 +33,16 @@ namespace Mindbox.Quokka
 		/// </summary>
 		public ArithmeticErrorReason Reason { get; }
 
-		/// <summary>
-		/// The source text of the failed expression as it is written in the template,
-		/// e.g. "cart.total / cart.itemCount". <c>Null</c> if the text can't be restored.
-		/// </summary>
-		public string Expression { get; }
-
 		public ArithmeticOperationException(
 			ArithmeticErrorReason reason,
 			string expression,
 			Location location,
 			Exception inner)
-			: base(BuildMessage(reason, expression, location), inner, location)
+			: base(ErrorText, GetReasonText(reason), expression, location, inner)
 		{
 			Reason = reason;
-			Expression = expression;
 
-			Data[QuokkaExceptionData.ErrorText] = ErrorText;
 			Data[QuokkaExceptionData.Reason] = reason.ToString();
-
-			if (expression != null)
-				Data[QuokkaExceptionData.Expression] = expression;
 		}
 
 		/// <summary>
@@ -75,19 +64,6 @@ namespace Mindbox.Quokka
 				default:
 					throw new ArgumentOutOfRangeException(nameof(reason), reason, null);
 			}
-		}
-
-		private static string BuildMessage(ArithmeticErrorReason reason, string expression, Location location)
-		{
-			var message = $"{ErrorText}: {GetReasonText(reason)}";
-
-			if (!string.IsNullOrWhiteSpace(expression))
-				message += $" in \"{expression}\"";
-
-			if (location != null)
-				message += $" at {location}";
-
-			return message;
 		}
 	}
 }

--- a/Engine/Mindbox.Quokka.Abstractions/Exceptions/QuokkaExceptionData.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Exceptions/QuokkaExceptionData.cs
@@ -1,0 +1,56 @@
+﻿// // Copyright 2022 Mindbox Ltd
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+namespace Mindbox.Quokka
+{
+	/// <summary>
+	/// Keys of the <see cref="System.Exception.Data"/> entries filled in by template exceptions.
+	/// The entries hold the parts the exception message is built from, so that the calling code
+	/// can render its own message (e.g. a localized one) without parsing the message text.
+	/// </summary>
+	public static class QuokkaExceptionData
+	{
+		/// <summary>
+		/// The error text without any details appended to it, e.g.
+		/// "Arithmetic operation result could not be evaluated". Value type is <see cref="string"/>.
+		/// </summary>
+		public const string ErrorText = "Quokka.ErrorText";
+
+		/// <summary>
+		/// The name of the reason enumeration member, e.g. "DivisionByZero". Value type is <see cref="string"/>.
+		/// </summary>
+		public const string Reason = "Quokka.Reason";
+
+		/// <summary>
+		/// The source text of the template expression which failed, e.g. "cart.total / cart.itemCount".
+		/// Value type is <see cref="string"/>.
+		/// </summary>
+		public const string Expression = "Quokka.Expression";
+
+		/// <summary>
+		/// The location of the failure within the template in the "line:column" form. Value type is <see cref="string"/>.
+		/// </summary>
+		public const string Location = "Quokka.Location";
+
+		/// <summary>
+		/// The line of the failure within the template. Value type is <see cref="int"/>.
+		/// </summary>
+		public const string Line = "Quokka.Line";
+
+		/// <summary>
+		/// The column of the failure within the template. Value type is <see cref="int"/>.
+		/// </summary>
+		public const string Column = "Quokka.Column";
+	}
+}

--- a/Engine/Mindbox.Quokka.Abstractions/Exceptions/QuokkaExceptionData.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Exceptions/QuokkaExceptionData.cs
@@ -15,7 +15,8 @@
 namespace Mindbox.Quokka
 {
 	/// <summary>
-	/// Keys of the <see cref="System.Exception.Data"/> entries filled in by template exceptions.
+	/// Keys of the <see cref="System.Exception.Data"/> entries filled in by runtime render errors
+	/// (<see cref="UnrenderableTemplateModelException"/> and its descendants).
 	/// The entries hold the parts the exception message is built from, so that the calling code
 	/// can render its own message (e.g. a localized one) without parsing the message text.
 	/// </summary>

--- a/Engine/Mindbox.Quokka.Abstractions/Exceptions/UnrenderableTemplateModelException.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Exceptions/UnrenderableTemplateModelException.cs
@@ -45,7 +45,8 @@ namespace Mindbox.Quokka
 
 		/// <summary>
 		/// The source text of the failed expression as it is written in the template,
-		/// e.g. "cart.total / cart.itemCount". <c>Null</c> if the text can't be restored.
+		/// e.g. "cart.total / cart.itemCount", truncated if it is too long.
+		/// <c>Null</c> if the text can't be restored.
 		/// </summary>
 		public string Expression { get; }
 
@@ -72,12 +73,12 @@ namespace Mindbox.Quokka
 			: base(BuildMessage(errorText, details, expression, location), inner)
 		{
 			Location = location;
-			Expression = expression;
+			Expression = string.IsNullOrWhiteSpace(expression) ? null : expression;
 
 			Data[QuokkaExceptionData.ErrorText] = errorText;
 
-			if (expression != null)
-				Data[QuokkaExceptionData.Expression] = expression;
+			if (Expression != null)
+				Data[QuokkaExceptionData.Expression] = Expression;
 
 			FillLocationData(location);
 		}

--- a/Engine/Mindbox.Quokka.Abstractions/Exceptions/UnrenderableTemplateModelException.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Exceptions/UnrenderableTemplateModelException.cs
@@ -30,12 +30,24 @@ namespace Mindbox.Quokka
 			: base(message)
 		{
 			Location = location;
+			FillLocationData(location);
 		}
 
 		public UnrenderableTemplateModelException(string message, Exception inner, Location location)
 			: base(message, inner)
 		{
 			Location = location;
+			FillLocationData(location);
+		}
+
+		private void FillLocationData(Location location)
+		{
+			if (location == null)
+				return;
+
+			Data[QuokkaExceptionData.Location] = location.ToString();
+			Data[QuokkaExceptionData.Line] = location.Line;
+			Data[QuokkaExceptionData.Column] = location.Column;
 		}
 	}
 }

--- a/Engine/Mindbox.Quokka.Abstractions/Exceptions/UnrenderableTemplateModelException.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Exceptions/UnrenderableTemplateModelException.cs
@@ -24,7 +24,30 @@ namespace Mindbox.Quokka
 	[Serializable]
 	public class UnrenderableTemplateModelException : TemplateException
 	{
+		/// <summary>
+		/// The error text of a null value usage, without the expression and the location appended to it.
+		/// </summary>
+		public const string NullValueErrorText = "An attempt to use a null value";
+
+		/// <summary>
+		/// The error text of a variable whose value is not present in the model,
+		/// without the expression and the location appended to it.
+		/// </summary>
+		public const string ValueNotFoundErrorText = "Value for variable not found";
+
+		/// <summary>
+		/// The error text of a failed template function call, without the failure details,
+		/// the expression and the location appended to it.
+		/// </summary>
+		public const string FunctionFailedErrorText = "Function invocation resulted in error";
+
 		public Location Location { get; }
+
+		/// <summary>
+		/// The source text of the failed expression as it is written in the template,
+		/// e.g. "cart.total / cart.itemCount". <c>Null</c> if the text can't be restored.
+		/// </summary>
+		public string Expression { get; }
 
 		public UnrenderableTemplateModelException(string message, Location location)
 			: base(message)
@@ -38,6 +61,41 @@ namespace Mindbox.Quokka
 		{
 			Location = location;
 			FillLocationData(location);
+		}
+
+		public UnrenderableTemplateModelException(
+			string errorText,
+			string details,
+			string expression,
+			Location location,
+			Exception inner)
+			: base(BuildMessage(errorText, details, expression, location), inner)
+		{
+			Location = location;
+			Expression = expression;
+
+			Data[QuokkaExceptionData.ErrorText] = errorText;
+
+			if (expression != null)
+				Data[QuokkaExceptionData.Expression] = expression;
+
+			FillLocationData(location);
+		}
+
+		private static string BuildMessage(string errorText, string details, string expression, Location location)
+		{
+			var message = errorText;
+
+			if (!string.IsNullOrWhiteSpace(details))
+				message += $": {details}";
+
+			if (!string.IsNullOrWhiteSpace(expression))
+				message += $" in \"{expression}\"";
+
+			if (location != null)
+				message += $" at {location}";
+
+			return message;
 		}
 
 		private void FillLocationData(Location location)

--- a/Engine/Quokka.Core/Generated.Partials/QuokkaBaseVisitor.cs
+++ b/Engine/Quokka.Core/Generated.Partials/QuokkaBaseVisitor.cs
@@ -15,6 +15,7 @@
 using System;
 
 using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
 
 namespace Mindbox.Quokka.Generated
@@ -26,6 +27,16 @@ namespace Mindbox.Quokka.Generated
 		protected Location GetLocationFromToken(IToken token)
 		{
 			return new Location(token.Line, token.Column);
+		}
+
+		protected ExpressionSource GetExpressionSource(ParserRuleContext context)
+		{
+			var lastToken = context.Stop;
+			var text = lastToken != null && lastToken.StopIndex >= context.Start.StartIndex
+				? context.Start.InputStream.GetText(new Interval(context.Start.StartIndex, lastToken.StopIndex))
+				: null;
+
+			return new ExpressionSource(GetLocationFromToken(context.Start), text);
 		}
 
 		protected QuokkaBaseVisitor(VisitingContext visitingContext)

--- a/Engine/Quokka.Core/Generated.Partials/QuokkaBaseVisitor.cs
+++ b/Engine/Quokka.Core/Generated.Partials/QuokkaBaseVisitor.cs
@@ -29,12 +29,17 @@ namespace Mindbox.Quokka.Generated
 			return new Location(token.Line, token.Column);
 		}
 
+		private const int MaxExpressionSourceLength = 100;
+
 		protected ExpressionSource GetExpressionSource(ParserRuleContext context)
 		{
 			var lastToken = context.Stop;
 			var text = lastToken != null && lastToken.StopIndex >= context.Start.StartIndex
 				? context.Start.InputStream.GetText(new Interval(context.Start.StartIndex, lastToken.StopIndex))
 				: null;
+
+			if (text != null && text.Length > MaxExpressionSourceLength)
+				text = text.Substring(0, MaxExpressionSourceLength) + "…";
 
 			return new ExpressionSource(GetLocationFromToken(context.Start), text);
 		}

--- a/Engine/Quokka.Core/Templating/Expressions/Arithmetic/AdditionExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Arithmetic/AdditionExpression.cs
@@ -43,7 +43,8 @@ namespace Mindbox.Quokka
 			treeVisitor.EndVisit();
 		}
 
-		public AdditionExpression(IEnumerable<AdditionOperand> operands)
+		public AdditionExpression(ExpressionSource source, IEnumerable<AdditionOperand> operands)
+			: base(source)
 		{
 			this.operands = operands.ToList().AsReadOnly();
 		}

--- a/Engine/Quokka.Core/Templating/Expressions/Arithmetic/ArithmeticExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Arithmetic/ArithmeticExpression.cs
@@ -19,6 +19,13 @@ namespace Mindbox.Quokka
 {
 	internal abstract class ArithmeticExpression : Expression
 	{
+		private readonly ExpressionSource source;
+
+		protected ArithmeticExpression(ExpressionSource source)
+		{
+			this.source = source;
+		}
+
 		public abstract double GetValue(RenderContext renderContext);
 
 		public abstract void PerformSemanticAnalysis(AnalysisContext context);
@@ -67,7 +74,7 @@ namespace Mindbox.Quokka
 			// do nothing
 		}
 
-		private static object NormalizeValue(double value)
+		private object NormalizeValue(double value)
 		{
 			try
 			{
@@ -82,8 +89,18 @@ namespace Mindbox.Quokka
 			}
 			catch (OverflowException ex)
 			{
-				throw new UnrenderableTemplateModelException("Arithmetic operation result could not be evaluated", ex, null);
+				throw new ArithmeticOperationException(GetErrorReason(value), source?.Text, source?.Location, ex);
 			}
+		}
+
+		private static ArithmeticErrorReason GetErrorReason(double value)
+		{
+			if (Double.IsNaN(value))
+				return ArithmeticErrorReason.NotANumber;
+
+			return Double.IsInfinity(value)
+				? ArithmeticErrorReason.DivisionByZero
+				: ArithmeticErrorReason.ResultOutOfRange;
 		}
 	}
 }

--- a/Engine/Quokka.Core/Templating/Expressions/Arithmetic/MultiplicationExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Arithmetic/MultiplicationExpression.cs
@@ -28,7 +28,8 @@ namespace Mindbox.Quokka
 						: TypeDefinition.Decimal;
 		}
 
-		public MultiplicationExpression(IEnumerable<MultiplicationOperand> operands)
+		public MultiplicationExpression(ExpressionSource source, IEnumerable<MultiplicationOperand> operands)
+			: base(source)
 		{
 			this.operands = operands.ToList().AsReadOnly();
 		}

--- a/Engine/Quokka.Core/Templating/Expressions/Arithmetic/NegationExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Arithmetic/NegationExpression.cs
@@ -23,7 +23,8 @@ namespace Mindbox.Quokka
 			return innerExpression.GetResultType(context);
 		}
 
-		public NegationExpression(ArithmeticExpression innerExpression)
+		public NegationExpression(ExpressionSource source, ArithmeticExpression innerExpression)
+			: base(source)
 		{
 			this.innerExpression = innerExpression;
 		}

--- a/Engine/Quokka.Core/Templating/Expressions/Arithmetic/NumberExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Arithmetic/NumberExpression.cs
@@ -20,7 +20,8 @@ namespace Mindbox.Quokka
 	{
 		private readonly double number;
 
-		public NumberExpression(double number)
+		public NumberExpression(ExpressionSource source, double number)
+			: base(source)
 		{
 			this.number = number;
 		}

--- a/Engine/Quokka.Core/Templating/Expressions/Arithmetic/VariantValueArithmeticExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Arithmetic/VariantValueArithmeticExpression.cs
@@ -20,7 +20,8 @@ namespace Mindbox.Quokka
     {
 	    private readonly VariantValueExpression variantValueExpression;
 
-	    public VariantValueArithmeticExpression(VariantValueExpression variantValueExpression)
+	    public VariantValueArithmeticExpression(ExpressionSource source, VariantValueExpression variantValueExpression)
+			: base(source)
 	    {
 		    this.variantValueExpression = variantValueExpression;
 	    }

--- a/Engine/Quokka.Core/Templating/Expressions/ExpressionSource.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/ExpressionSource.cs
@@ -23,8 +23,8 @@ namespace Mindbox.Quokka
 		public Location Location { get; }
 
 		/// <summary>
-		/// The expression as it is written in the template. <c>Null</c> for expressions
-		/// whose text can't be restored from the parse tree.
+		/// The expression as it is written in the template, truncated if it is too long.
+		/// <c>Null</c> for expressions whose text can't be restored from the parse tree.
 		/// </summary>
 		public string Text { get; }
 

--- a/Engine/Quokka.Core/Templating/Expressions/ExpressionSource.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/ExpressionSource.cs
@@ -1,0 +1,37 @@
+﻿// // Copyright 2022 Mindbox Ltd
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+namespace Mindbox.Quokka
+{
+	/// <summary>
+	/// The place an expression comes from within the template text. Kept by the compiled expression
+	/// so that runtime errors can point at the exact expression which failed.
+	/// </summary>
+	internal sealed class ExpressionSource
+	{
+		public Location Location { get; }
+
+		/// <summary>
+		/// The expression as it is written in the template. <c>Null</c> for expressions
+		/// whose text can't be restored from the parse tree.
+		/// </summary>
+		public string Text { get; }
+
+		public ExpressionSource(Location location, string text)
+		{
+			Location = location;
+			Text = text;
+		}
+	}
+}

--- a/Engine/Quokka.Core/Templating/Expressions/Functions/FunctionCallExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Functions/FunctionCallExpression.cs
@@ -54,14 +54,14 @@ namespace Mindbox.Quokka
 			if (function == null)
 				throw new InvalidOperationException($"Function {FunctionName} not found");
 
+			var arguments = argumentValues
+				.Select((argumentValue, argumentNumber) =>
+					argumentValue.GetValue(renderContext, function.Arguments.GetArgument(argumentNumber)))
+				.ToList();
+
 			try
 			{
-				return function.Invoke(
-					renderContext,
-					argumentValues
-						.Select((argumentValue, argumentNumber) => 
-							argumentValue.GetValue(renderContext, function.Arguments.GetArgument(argumentNumber)))
-						.ToList());
+				return function.Invoke(renderContext, arguments);
 			}
 			catch (FunctionCallRuntimeException targetException)
 			{

--- a/Engine/Quokka.Core/Templating/Expressions/Functions/FunctionCallExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Functions/FunctionCallExpression.cs
@@ -22,15 +22,17 @@ namespace Mindbox.Quokka
 	{
 		public string FunctionName { get; }
 
-		public Location Location { get; }
+		public Location Location => source.Location;
+
+		private readonly ExpressionSource source;
 
 		private readonly IReadOnlyList<ArgumentValue> argumentValues;
 
-		public FunctionCallExpression(string functionName, IEnumerable<ArgumentValue> argumentValues, Location location)
+		public FunctionCallExpression(string functionName, IEnumerable<ArgumentValue> argumentValues, ExpressionSource source)
 		{
 			FunctionName = functionName;
 			this.argumentValues = argumentValues.ToList().AsReadOnly();
-			Location = location;
+			this.source = source;
 		}
 
 		public override void PerformSemanticAnalysis(AnalysisContext context, TypeDefinition expectedExpressionType)
@@ -63,14 +65,21 @@ namespace Mindbox.Quokka
 			}
 			catch (FunctionCallRuntimeException targetException)
 			{
-				throw new UnrenderableTemplateModelException(targetException.Message, targetException, Location);
+				throw new UnrenderableTemplateModelException(
+					UnrenderableTemplateModelException.FunctionFailedErrorText,
+					targetException.Message,
+					source.Text ?? FunctionName,
+					source.Location,
+					targetException);
 			}
 			catch (Exception ex)
 			{
 				throw new UnrenderableTemplateModelException(
-					$"Function {FunctionName} invocation resulted in error",
-					ex,
-					Location);
+					UnrenderableTemplateModelException.FunctionFailedErrorText,
+					null,
+					source.Text ?? FunctionName,
+					source.Location,
+					ex);
 			}
 		}
 

--- a/Engine/Quokka.Core/Templating/Expressions/Variables/MemberValueExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Variables/MemberValueExpression.cs
@@ -95,8 +95,11 @@ namespace Mindbox.Quokka
 									    .Take(i + 1)));
 
 					throw new UnrenderableTemplateModelException(
-						$"An attempt to use the value of \"{memberChainStringRepresentation}\" expression which happens to be null",
-						location);
+						UnrenderableTemplateModelException.NullValueErrorText,
+						null,
+						memberChainStringRepresentation,
+						location,
+						null);
 				}
 		    }
 

--- a/Engine/Quokka.Core/Templating/Expressions/Variables/VariableValueExpression.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Variables/VariableValueExpression.cs
@@ -67,8 +67,11 @@ namespace Mindbox.Quokka
 			var valueStorage = TryGetValueStorage(renderContext);
 			if (valueStorage == null || valueStorage.CheckIfValueIsNull())
 				throw new UnrenderableTemplateModelException(
-					$"An attempt to use the value of variable \"{variableName}\" which happens to be null",
-					variableLocation);
+					UnrenderableTemplateModelException.NullValueErrorText,
+					null,
+					variableName,
+					variableLocation,
+					null);
 
 			return valueStorage;
 		}
@@ -89,8 +92,11 @@ namespace Mindbox.Quokka
 		{
 			return renderContext.VariableScope.TryGetValueStorageForVariable(variableName) ??
 					throw new UnrenderableTemplateModelException(
-						$"Value for variable {variableName} not found",
-						variableLocation);
+						UnrenderableTemplateModelException.ValueNotFoundErrorText,
+						null,
+						variableName,
+						variableLocation,
+						null);
 		}
 
 

--- a/Engine/Quokka.Core/Templating/Visitors/Expressions/ArithmeticExpressionVisitor.cs
+++ b/Engine/Quokka.Core/Templating/Visitors/Expressions/ArithmeticExpressionVisitor.cs
@@ -45,7 +45,7 @@ namespace Mindbox.Quokka
 				.Skip(1)
 				.Select(child => child.Accept(new AdditionalExpressionVisitor(VisitingContext))));
 
-			return new AdditionExpression(operands);
+			return new AdditionExpression(GetExpressionSource(context), operands);
 		}
 
 		public override ArithmeticExpression VisitMultiplicationExpression(QuokkaParser.MultiplicationExpressionContext context)
@@ -67,26 +67,30 @@ namespace Mindbox.Quokka
 				.Skip(1)
 				.Select(child => child.Accept(new MultiplicativeExpressionVisitor(VisitingContext))));
 
-			return new MultiplicationExpression(operands);
+			return new MultiplicationExpression(GetExpressionSource(context), operands);
 		}
 
 		public override ArithmeticExpression VisitNegationExpression(QuokkaParser.NegationExpressionContext context)
 		{
-			return new NegationExpression(Visit(context.arithmeticAtom()));
+			return new NegationExpression(GetExpressionSource(context), Visit(context.arithmeticAtom()));
 		}
 
 		public override ArithmeticExpression VisitArithmeticAtom(QuokkaParser.ArithmeticAtomContext context)
 		{
 			var number = context.Number();
 			if (number != null)
-				return new NumberExpression(double.Parse(number.GetText(), CultureInfo.InvariantCulture));
+				return new NumberExpression(
+					GetExpressionSource(context),
+					double.Parse(number.GetText(), CultureInfo.InvariantCulture));
 
 			return base.VisitArithmeticAtom(context);
 		}
 
 		public override ArithmeticExpression VisitVariantValueExpression(QuokkaParser.VariantValueExpressionContext context)
 		{
-			return new VariantValueArithmeticExpression(context.Accept(new VariantValueExpressionVisitor(VisitingContext)));
+			return new VariantValueArithmeticExpression(
+				GetExpressionSource(context),
+				context.Accept(new VariantValueExpressionVisitor(VisitingContext)));
 		}
 
 		protected override ArithmeticExpression AggregateResult(ArithmeticExpression aggregate, ArithmeticExpression nextResult)

--- a/Engine/Quokka.Core/Templating/Visitors/Expressions/FunctionCallExpressionVisitor.cs
+++ b/Engine/Quokka.Core/Templating/Visitors/Expressions/FunctionCallExpressionVisitor.cs
@@ -51,7 +51,7 @@ namespace Mindbox.Quokka
 			return new FunctionCallExpression(
 				functionNameToken.GetText(),
 				arguments,
-				GetLocationFromToken(functionNameToken.Symbol));
+				GetExpressionSource(context));
 		}
 	}
 }

--- a/Engine/Quokka.Tests/Rendering/RenderArithmeticErrorsTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderArithmeticErrorsTests.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Mindbox.Quokka.Abstractions;
+
 namespace Mindbox.Quokka.Tests
 {
 	[TestClass]
@@ -156,6 +158,55 @@ namespace Mindbox.Quokka.Tests
 			Assert.AreEqual("1:3", exception.Data[QuokkaExceptionData.Location]);
 			Assert.AreEqual(1, exception.Data[QuokkaExceptionData.Line]);
 			Assert.AreEqual(3, exception.Data[QuokkaExceptionData.Column]);
+		}
+
+		[TestMethod]
+		public void Render_DivisionByZeroInFunctionArgument_ReportsArithmeticError()
+		{
+			var template = new DefaultTemplateFactory(new[] { new EchoFunction() })
+				.CreateTemplate("${ echo(Total / OrderCount) }");
+
+			var exception = Assert.ThrowsException<ArithmeticOperationException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("Total", 500),
+						new ModelField("OrderCount", 0))));
+
+			Assert.AreEqual(ArithmeticErrorReason.DivisionByZero, exception.Reason);
+			Assert.AreEqual("Total / OrderCount", exception.Expression);
+		}
+
+		[TestMethod]
+		public void Render_FailedExpressionLongerThanLimit_TruncatesReportedExpression()
+		{
+			var template = new Template(
+				"${ TheFirstVeryLongVariableName + TheSecondVeryLongVariableName "
+					+ "+ TheThirdVeryLongVariableName + TheFourthVeryLongVariableName / DivisorWhichHappensToBeZero }");
+
+			var exception = Assert.ThrowsException<ArithmeticOperationException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("TheFirstVeryLongVariableName", 1),
+						new ModelField("TheSecondVeryLongVariableName", 2),
+						new ModelField("TheThirdVeryLongVariableName", 3),
+						new ModelField("TheFourthVeryLongVariableName", 4),
+						new ModelField("DivisorWhichHappensToBeZero", 0))));
+
+			Assert.AreEqual(101, exception.Expression.Length);
+			Assert.IsTrue(exception.Expression.EndsWith("…"));
+		}
+
+		private class EchoFunction : ScalarTemplateFunction<decimal, decimal>
+		{
+			public EchoFunction()
+				: base("echo", new DecimalFunctionArgument("number"))
+			{
+			}
+
+			public override decimal Invoke(RenderSettings settings, decimal value)
+			{
+				return value;
+			}
 		}
 	}
 }

--- a/Engine/Quokka.Tests/Rendering/RenderArithmeticErrorsTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderArithmeticErrorsTests.cs
@@ -1,0 +1,161 @@
+﻿// // Copyright 2022 Mindbox Ltd
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Mindbox.Quokka.Tests
+{
+	[TestClass]
+	public class RenderArithmeticErrorsTests
+	{
+		[TestMethod]
+		public void Render_DivisionByZero_ReportsReasonExpressionAndLocation()
+		{
+			var template = new Template("Average check: ${ Total / OrderCount }");
+
+			var exception = Assert.ThrowsException<ArithmeticOperationException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("Total", 500),
+						new ModelField("OrderCount", 0))));
+
+			Assert.AreEqual(ArithmeticErrorReason.DivisionByZero, exception.Reason);
+			Assert.AreEqual("Total / OrderCount", exception.Expression);
+			Assert.AreEqual(1, exception.Location.Line);
+			Assert.AreEqual(18, exception.Location.Column);
+			Assert.AreEqual(
+				"Arithmetic operation result could not be evaluated: division by zero "
+					+ "in \"Total / OrderCount\" at 1:18",
+				exception.Message);
+		}
+
+		[TestMethod]
+		public void Render_ZeroDividedByZero_ReportsNotANumber()
+		{
+			var template = new Template("${ Total / OrderCount }");
+
+			var exception = Assert.ThrowsException<ArithmeticOperationException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("Total", 0),
+						new ModelField("OrderCount", 0))));
+
+			Assert.AreEqual(ArithmeticErrorReason.NotANumber, exception.Reason);
+			Assert.AreEqual(
+				"Arithmetic operation result could not be evaluated: the result is not a number "
+					+ "in \"Total / OrderCount\" at 1:3",
+				exception.Message);
+		}
+
+		[TestMethod]
+		public void Render_ResultTooLargeToBeRepresented_ReportsResultOutOfRange()
+		{
+			var template = new Template("${ First * Second }");
+
+			var exception = Assert.ThrowsException<ArithmeticOperationException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("First", 1000000000000000m),
+						new ModelField("Second", 1000000000000000m))));
+
+			Assert.AreEqual(ArithmeticErrorReason.ResultOutOfRange, exception.Reason);
+			Assert.AreEqual(
+				"Arithmetic operation result could not be evaluated: the result is out of the supported number range "
+					+ "in \"First * Second\" at 1:3",
+				exception.Message);
+		}
+
+		[TestMethod]
+		public void Render_DivisionByZero_ReportsLocationWithinMultilineTemplate()
+		{
+			var template = new Template(
+				"Hello!\r\n"
+					+ "Your average check is ${ Total / OrderCount }.\r\n"
+					+ "Bye!");
+
+			var exception = Assert.ThrowsException<ArithmeticOperationException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("Total", 500),
+						new ModelField("OrderCount", 0))));
+
+			Assert.AreEqual(2, exception.Location.Line);
+			Assert.AreEqual(25, exception.Location.Column);
+		}
+
+		[TestMethod]
+		public void Render_DivisionByZeroWithinLargerExpression_ReportsWholeExpression()
+		{
+			var template = new Template("${ Total / OrderCount + 1 }");
+
+			var exception = Assert.ThrowsException<ArithmeticOperationException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("Total", 500),
+						new ModelField("OrderCount", 0))));
+
+			Assert.AreEqual("Total / OrderCount + 1", exception.Expression);
+		}
+
+		[TestMethod]
+		public void Render_DivisionByZero_FillsExceptionDataWithMessageParts()
+		{
+			var template = new Template("${ Total / OrderCount }");
+
+			var exception = Assert.ThrowsException<ArithmeticOperationException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("Total", 500),
+						new ModelField("OrderCount", 0))));
+
+			Assert.AreEqual(
+				"Arithmetic operation result could not be evaluated",
+				exception.Data[QuokkaExceptionData.ErrorText]);
+			Assert.AreEqual("DivisionByZero", exception.Data[QuokkaExceptionData.Reason]);
+			Assert.AreEqual("Total / OrderCount", exception.Data[QuokkaExceptionData.Expression]);
+			Assert.AreEqual("1:3", exception.Data[QuokkaExceptionData.Location]);
+			Assert.AreEqual(1, exception.Data[QuokkaExceptionData.Line]);
+			Assert.AreEqual(3, exception.Data[QuokkaExceptionData.Column]);
+		}
+
+		[TestMethod]
+		public void Render_DivisionByZero_IsStillCaughtAsUnrenderableTemplateModelException()
+		{
+			var template = new Template("${ Total / OrderCount }");
+
+			var exception = Assert.ThrowsException<ArithmeticOperationException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("Total", 500),
+						new ModelField("OrderCount", 0))));
+
+			Assert.IsInstanceOfType(exception, typeof(UnrenderableTemplateModelException));
+		}
+
+		[TestMethod]
+		public void Render_NullValueError_FillsExceptionDataWithLocation()
+		{
+			var template = new Template("${ Total }");
+
+			var exception = Assert.ThrowsException<UnrenderableTemplateModelException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("Total", new PrimitiveModelValue(null)))));
+
+			Assert.AreEqual("1:3", exception.Data[QuokkaExceptionData.Location]);
+			Assert.AreEqual(1, exception.Data[QuokkaExceptionData.Line]);
+			Assert.AreEqual(3, exception.Data[QuokkaExceptionData.Column]);
+		}
+	}
+}

--- a/Engine/Quokka.Tests/Rendering/RenderCollectionFunctionsTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderCollectionFunctionsTests.cs
@@ -547,7 +547,7 @@ namespace Mindbox.Quokka.Tests
 			catch (UnrenderableTemplateModelException exception)
 			{
 				Assert.AreEqual(
-					"An attempt to use the value of \"cell.Value\" expression which happens to be null",
+					"An attempt to use a null value in \"cell.Value\" at 4:14",
 					exception.Message);
 				return;
 			}

--- a/Engine/Quokka.Tests/Rendering/RenderExceptionsTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderExceptionsTests.cs
@@ -61,9 +61,67 @@ namespace Mindbox.Quokka
 						new ArrayModelValue())));
 		}
 
+		[TestMethod]
+		public void Render_NullVariableValue_ReportsExpressionAndLocation()
+		{
+			var template = new Template("Hello, ${ FirstName }!");
+
+			var exception = Assert.ThrowsException<UnrenderableTemplateModelException>(
+				() => template.Render(
+					new CompositeModelValue(
+						new ModelField("FirstName", new PrimitiveModelValue(null)))));
+
+			Assert.AreEqual("An attempt to use a null value in \"FirstName\" at 1:10", exception.Message);
+			Assert.AreEqual("FirstName", exception.Expression);
+		}
+
+		[TestMethod]
+		public void Render_VariableValueNotFound_ReportsExpressionAndLocation()
+		{
+			var template = new Template("@{ if 1 < 0 }@{ set a = 5 }@{ end if }${ a }");
+
+			var exception = Assert.ThrowsException<UnrenderableTemplateModelException>(
+				() => template.Render(new CompositeModelValue()));
+
+			Assert.AreEqual("Value for variable not found in \"a\" at 1:41", exception.Message);
+		}
+
+		[TestMethod]
+		public void Render_FunctionInvocationError_ReportsExpressionLocationAndDataParts()
+		{
+			var template = new DefaultTemplateFactory(new[] { new FaultyFunction() })
+				.CreateTemplate("${ fail() }");
+
+			var exception = Assert.ThrowsException<UnrenderableTemplateModelException>(
+				() => template.Render(new CompositeModelValue()));
+
+			Assert.AreEqual("Function invocation resulted in error in \"fail()\" at 1:3", exception.Message);
+			Assert.AreEqual(
+				UnrenderableTemplateModelException.FunctionFailedErrorText,
+				exception.Data[QuokkaExceptionData.ErrorText]);
+			Assert.AreEqual("fail()", exception.Data[QuokkaExceptionData.Expression]);
+			Assert.AreEqual("1:3", exception.Data[QuokkaExceptionData.Location]);
+			Assert.AreEqual(1, exception.Data[QuokkaExceptionData.Line]);
+			Assert.AreEqual(3, exception.Data[QuokkaExceptionData.Column]);
+		}
+
+		[TestMethod]
+		public void Render_FunctionRuntimeError_ReportsFunctionMessageExpressionAndLocation()
+		{
+			var template = new DefaultTemplateFactory(new[] { new PickyFunction() })
+				.CreateTemplate("${ picky() }");
+
+			var exception = Assert.ThrowsException<UnrenderableTemplateModelException>(
+				() => template.Render(new CompositeModelValue()));
+
+			Assert.AreEqual(
+				"Function invocation resulted in error: Argument must be positive in \"picky()\" at 1:3",
+				exception.Message);
+		}
+
 		private class FaultyFunction : ScalarTemplateFunction
 	    {
-		    public FaultyFunction() 
+		    public FaultyFunction()
 				: base("fail", typeof(int))
 		    {
 		    }
@@ -75,5 +133,20 @@ namespace Mindbox.Quokka
 			    throw new Exception("Error");
 		    }
 	    }
+
+		private class PickyFunction : ScalarTemplateFunction
+		{
+			public PickyFunction()
+				: base("picky", typeof(int))
+			{
+			}
+
+			internal override object GetScalarInvocationResult(
+				RenderContext renderContext,
+				IList<VariableValueStorage> argumentsValues)
+			{
+				throw new FunctionCallRuntimeException("Argument must be positive", null);
+			}
+		}
     }
 }

--- a/Engine/Quokka.Tests/Rendering/RenderExceptionsTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderExceptionsTests.cs
@@ -39,8 +39,7 @@ namespace Mindbox.Quokka
 		[ExpectedException(typeof(UnrenderableTemplateModelException), AllowDerivedTypes = true)]
 		public void Render_DivisionByZero_UnrendereableException()
 		{
-			var template = new DefaultTemplateFactory(new[] { new FaultyFunction() })
-				.CreateTemplate("${ 5 / 0 }");
+			var template = new Template("${ 5 / 0 }");
 			template.Render(new CompositeModelValue());
 		}
 

--- a/Engine/Quokka.Tests/Rendering/RenderExceptionsTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderExceptionsTests.cs
@@ -36,7 +36,7 @@ namespace Mindbox.Quokka
 		}
 
 		[TestMethod]
-		[ExpectedException(typeof(UnrenderableTemplateModelException))]
+		[ExpectedException(typeof(UnrenderableTemplateModelException), AllowDerivedTypes = true)]
 		public void Render_DivisionByZero_UnrendereableException()
 		{
 			var template = new DefaultTemplateFactory(new[] { new FaultyFunction() })


### PR DESCRIPTION
Previously runtime render errors were hard to trace back to the template: an arithmetic failure was reported as a bare `Arithmetic operation result could not be evaluated` with no location at all, and the other runtime errors (a null value usage, a missing variable value, a failed function call) named the variable or the function but never the location.

Every runtime render error now reports the expression as it is written in the template and the location, in one message shape built in one place (the `UnrenderableTemplateModelException` base):

```
<error text>[: <details>][ in "<expression>"][ at <line:column>]
```

```
Arithmetic operation result could not be evaluated: division by zero in "cart.total / cart.itemCount" at 12:34
An attempt to use a null value in "cell.Value" at 4:14
Value for variable not found in "a" at 1:41
Function invocation resulted in error: Argument must be positive in "picky()" at 1:3
```

Arithmetic failures are thrown as `ArithmeticOperationException` with a typed `Reason`: `DivisionByZero`, `NotANumber` or `ResultOutOfRange`. The other error texts are exposed as constants on the base exception, and the failed expression is a typed `Expression` property on it.

The same parts are put into `Exception.Data` under the `QuokkaExceptionData` keys (`ErrorText`, `Reason`, `Expression`, `Location`, `Line`, `Column`), so that the calling code can build its own (e.g. localized) message for any runtime error without parsing the message text.

Details:

- A runtime error raised while evaluating a function argument propagates as itself instead of being re-wrapped into a generic function failure, so e.g. a division by zero inside `max(a / b, 1)` keeps its reason and expression.
- The captured expression text is template source only (variable values are never put into messages or `Data`) and is capped at 100 characters.
- `Location.Column` is documented as 0-based, matching the values the engine has always produced.
- `ArithmeticOperationException` derives from `UnrenderableTemplateModelException` and the other errors keep their exception type, so the existing catch blocks keep working.
- Version bumped to 8.4.0: new public API and changed error message texts.

Tests: 494/494 green on net8.0 and net9.0 (14 new). Two existing tests were adjusted: the division-by-zero one now allows a derived exception type, and the null-cell-value one asserts the new message wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)