### PR TITLE
Number the calls of non-idempotent methods so identical expressions get separate requirements

### DIFF
--- a/Engine/Directory.Build.props
+++ b/Engine/Directory.Build.props
@@ -16,6 +16,6 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <VersionPrefix>8.5.0</VersionPrefix>
+        <VersionPrefix>8.6.0</VersionPrefix>
     </PropertyGroup>
 </Project>

--- a/Engine/Mindbox.Quokka.Abstractions/Model/Definitions/IMethodCallDefinition.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Model/Definitions/IMethodCallDefinition.cs
@@ -20,5 +20,11 @@ namespace Mindbox.Quokka
     {
         string Name { get; }
         IReadOnlyList<IMethodArgumentDefinition> Arguments { get; }
+
+        /// <summary>
+        /// The 1-based number of this call among the calls of a non-idempotent method with the same name and arguments,
+        /// or <c>null</c> if the method is idempotent and all its identical calls share a single definition.
+        /// </summary>
+        int? CallOrdinal { get; }
     }
 }

--- a/Engine/Mindbox.Quokka.Abstractions/Model/InputValues/IModelMethod.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Model/InputValues/IModelMethod.cs
@@ -22,6 +22,12 @@ namespace Mindbox.Quokka
 
 		IReadOnlyList<object> Arguments { get; }
 
+		/// <summary>
+		/// The <see cref="IMethodCallDefinition.CallOrdinal"/> of the call this value belongs to,
+		/// or <c>null</c> for a value shared by all the calls of an idempotent method.
+		/// </summary>
+		int? CallOrdinal { get; }
+
 	    IModelValue Value { get; }
 	}
 }

--- a/Engine/Quokka.Core/DefaultTemplateFactory.cs
+++ b/Engine/Quokka.Core/DefaultTemplateFactory.cs
@@ -12,6 +12,7 @@
 // // See the License for the specific language governing permissions and
 // // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -23,23 +24,32 @@ namespace Mindbox.Quokka
 	{
 		private readonly FunctionRegistry functionRegistry;
 
-		public DefaultTemplateFactory(IEnumerable<TemplateFunction> additionalFunctions = null)
+		private readonly IReadOnlyCollection<string> nonIdempotentMethodNames;
+
+		public DefaultTemplateFactory(
+			IEnumerable<TemplateFunction> additionalFunctions = null,
+			IEnumerable<string> nonIdempotentMethodNames = null)
 		{
 			var functions = new List<TemplateFunction>(Template.GetStandardFunctions());
 			if (additionalFunctions != null)
 				functions.AddRange(additionalFunctions);
 			
 			functionRegistry = new FunctionRegistry(functions);
+			this.nonIdempotentMethodNames = nonIdempotentMethodNames?.ToArray() ?? Array.Empty<string>();
 		}
 
 		public ITemplate CreateTemplate(string templateText)
 		{
-			return new Template(templateText, functionRegistry,  true);
+			return new Template(templateText, functionRegistry,  true, nonIdempotentMethodNames: nonIdempotentMethodNames);
 		}
 
 		public ITemplate TryCreateTemplate(string templateText, out IList<ITemplateError> errors)
 		{
-			var template = new Template(templateText, functionRegistry, false);
+			var template = new Template(
+				templateText,
+				functionRegistry,
+				false,
+				nonIdempotentMethodNames: nonIdempotentMethodNames);
 			errors = template.Errors;
 
 			return errors.Any() ? null : template;
@@ -47,12 +57,12 @@ namespace Mindbox.Quokka
 
 		public IHtmlTemplate CreateHtmlTemplate(string templateText)
 		{
-			return new HtmlTemplate(templateText, functionRegistry, true);
+			return new HtmlTemplate(templateText, functionRegistry, true, nonIdempotentMethodNames);
 		}
 
 		public IHtmlTemplate TryCreateHtmlTemplate(string templateText, out IList<ITemplateError> errors)
 		{
-			var template = new HtmlTemplate(templateText, functionRegistry, false);
+			var template = new HtmlTemplate(templateText, functionRegistry, false, nonIdempotentMethodNames);
 			errors = template.Errors;
 
 			return errors.Any() ? null : template;

--- a/Engine/Quokka.Core/Html/HtmlTemplate.cs
+++ b/Engine/Quokka.Core/Html/HtmlTemplate.cs
@@ -27,13 +27,15 @@ namespace Mindbox.Quokka.Html
 		internal HtmlTemplate(
 			string templateText,
 			FunctionRegistry functionRegistry,
-			bool throwIfErrorsEncountered = true)
+			bool throwIfErrorsEncountered = true,
+			IEnumerable<string> nonIdempotentMethodNames = null)
 			: base(
 				templateText,
 				functionRegistry,
 				throwIfErrorsEncountered,
 				context => new HtmlStaticBlockVisitor(context),
-				new[] { new HtmlSemanticErrorSubListener() })
+				new[] { new HtmlSemanticErrorSubListener() },
+				nonIdempotentMethodNames)
 		{
 		}
 

--- a/Engine/Quokka.Core/Model/Definitions/MethodCallDefinition.cs
+++ b/Engine/Quokka.Core/Model/Definitions/MethodCallDefinition.cs
@@ -24,10 +24,16 @@ namespace Mindbox.Quokka
 
 		public IReadOnlyList<IMethodArgumentDefinition> Arguments { get; }
 
-	    internal MethodCallDefinition(string name, IReadOnlyList<IMethodArgumentDefinition> arguments)
+		public int? CallOrdinal { get; }
+
+	    internal MethodCallDefinition(
+		    string name,
+		    IReadOnlyList<IMethodArgumentDefinition> arguments,
+		    int? callOrdinal = null)
 	    {
 		    Name = name;
 		    Arguments = arguments;
+		    CallOrdinal = callOrdinal;
 	    }
 
 		public bool Equals(IMethodCallDefinition other)
@@ -36,6 +42,9 @@ namespace Mindbox.Quokka
 				return false;
 
 			if (!StringComparer.OrdinalIgnoreCase.Equals(Name, other.Name))
+				return false;
+
+			if (CallOrdinal != other.CallOrdinal)
 				return false;
 
 			if (Arguments.Count != other.Arguments.Count)
@@ -75,7 +84,8 @@ namespace Mindbox.Quokka
 		}
 
 		public override string ToString() => 
-			$"{Name}({string.Join(", ", Arguments.Select(arg => $"{arg.Type.Name}: {arg.Value}"))})";
+			$"{Name}({string.Join(", ", Arguments.Select(arg => $"{arg.Type.Name}: {arg.Value}"))})"
+			+ (CallOrdinal == null ? string.Empty : $"#{CallOrdinal}");
 	}
 
 

--- a/Engine/Quokka.Core/Model/InputValues/ModelMethod.cs
+++ b/Engine/Quokka.Core/Model/InputValues/ModelMethod.cs
@@ -24,6 +24,7 @@ namespace Mindbox.Quokka
     {
 		public string Name { get; }
 	    public IReadOnlyList<object> Arguments { get; }
+	    public int? CallOrdinal { get; }
 		public IModelValue Value { get; }
 
 	    public ModelMethod(string name, IModelValue value)
@@ -36,15 +37,16 @@ namespace Mindbox.Quokka
 	    {
 	    }
 		
-	    public ModelMethod(string name, IEnumerable<object> arguments, IModelValue value)
+	    public ModelMethod(string name, IEnumerable<object> arguments, IModelValue value, int? callOrdinal = null)
 	    {
 		    Name = name;
 		    Arguments = arguments.ToArray();
+		    CallOrdinal = callOrdinal;
 		    Value = value;
 	    }
 
-	    public ModelMethod(string name, IEnumerable<object> arguments, object primitiveValue)
-		    : this(name, arguments, new PrimitiveModelValue(primitiveValue))
+	    public ModelMethod(string name, IEnumerable<object> arguments, object primitiveValue, int? callOrdinal = null)
+		    : this(name, arguments, new PrimitiveModelValue(primitiveValue), callOrdinal)
 	    {
 	    }
 	}

--- a/Engine/Quokka.Core/Model/ModelValidator.cs
+++ b/Engine/Quokka.Core/Model/ModelValidator.cs
@@ -101,7 +101,7 @@ namespace Mindbox.Quokka
 			var requiredMethods = requiredModelDefinition.Methods.ToList();
 			var actualMethods = model
 				.Methods
-				.ToDictionary(method => new MethodCall(method.Name, method.Arguments));
+				.ToDictionary(method => new MethodCall(method.Name, method.Arguments, method.CallOrdinal));
 
 			foreach (var requiredMethod in requiredMethods)
 			{
@@ -111,7 +111,8 @@ namespace Mindbox.Quokka
 
 				var requiredMethodCall = new MethodCall(
 					requiredMethod.Key.Name,
-					requiredMethod.Key.Arguments.Select(arg => arg.Value).ToArray());
+					requiredMethod.Key.Arguments.Select(arg => arg.Value).ToArray(),
+					requiredMethod.Key.CallOrdinal);
 
 				if (!actualMethods.TryGetValue(requiredMethodCall, out IModelMethod actualMethod))
 				{

--- a/Engine/Quokka.Core/Rendering/Values/CompositeVariableValueStorage.cs
+++ b/Engine/Quokka.Core/Rendering/Values/CompositeVariableValueStorage.cs
@@ -42,7 +42,7 @@ namespace Mindbox.Quokka
 			methods = modelValue
 				.Methods
 				.ToDictionary(
-					method => new MethodCall(method.Name, method.Arguments), 
+					method => new MethodCall(method.Name, method.Arguments, method.CallOrdinal), 
 					method => method.Value != null ? CreateStorageForValue(method.Value) : null);
 		}
 

--- a/Engine/Quokka.Core/Semantics/Variables/MethodCall.cs
+++ b/Engine/Quokka.Core/Semantics/Variables/MethodCall.cs
@@ -22,12 +22,15 @@ namespace Mindbox.Quokka
     {
 		public string Name { get; }
 
+	    public int? CallOrdinal { get; }
+
 	    private readonly IReadOnlyList<object> argumentValues;
 
-	    public MethodCall(string name, IReadOnlyList<object> argumentValues)
+	    public MethodCall(string name, IReadOnlyList<object> argumentValues, int? callOrdinal = null)
 	    {
 		    Name = name;
 		    this.argumentValues = argumentValues;
+		    CallOrdinal = callOrdinal;
 	    }
 
 	    public IMethodCallDefinition ToMethodCallDefinition()
@@ -39,7 +42,8 @@ namespace Mindbox.Quokka
 						    new MethodArgumentDefinition(
 							    TypeDefinition.GetTypeDefinitionByRuntimeType(argumentValue.GetType()),
 							    argumentValue))
-				    .ToArray());
+				    .ToArray(),
+			    CallOrdinal);
 	    }
 
 	    public bool Equals(MethodCall other)
@@ -50,6 +54,9 @@ namespace Mindbox.Quokka
 			    return true;
 
 		    if (!StringComparer.OrdinalIgnoreCase.Equals(Name, other.Name))
+			    return false;
+
+		    if (CallOrdinal != other.CallOrdinal)
 			    return false;
 
 		    if (argumentValues.Count != other.argumentValues.Count)
@@ -91,7 +98,9 @@ namespace Mindbox.Quokka
 
 	    public override string ToString()
 	    {
-		    return $"{Name}({string.Join(", ", argumentValues)})";
+		    var callOrdinalSuffix = CallOrdinal == null ? string.Empty : $"#{CallOrdinal}";
+
+		    return $"{Name}({string.Join(", ", argumentValues)}){callOrdinalSuffix}";
 	    }
     }
 }

--- a/Engine/Quokka.Core/Template.cs
+++ b/Engine/Quokka.Core/Template.cs
@@ -44,7 +44,8 @@ namespace Mindbox.Quokka
 			FunctionRegistry functionRegistry,
 			bool throwIfErrorsEncountered = true,
 			Func<VisitingContext, IQuokkaVisitor<StaticBlock>> staticBlockVisitorCreator = null,
-			IEnumerable<SemanticErrorSubListenerBase> semanticErrorSubListeners = null)
+			IEnumerable<SemanticErrorSubListenerBase> semanticErrorSubListeners = null,
+			IEnumerable<string> nonIdempotentMethodNames = null)
 		{
 			ArgumentNullException.ThrowIfNull(templateText);
 			ArgumentNullException.ThrowIfNull(functionRegistry);
@@ -69,7 +70,8 @@ namespace Mindbox.Quokka
 				{
 					VisitingContext visitingContext = new VisitingContext(
 						syntaxErrorListener,
-						staticBlockVisitorCreator ?? (context => new StaticBlockVisitor(context)));
+						staticBlockVisitorCreator ?? (context => new StaticBlockVisitor(context)),
+						nonIdempotentMethodNames);
 
 					compiledTemplateTree = new RootTemplateVisitor(visitingContext).Visit(templateParseTree);
 

--- a/Engine/Quokka.Core/Templating/Expressions/Variables/MethodMember.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Variables/MethodMember.cs
@@ -21,14 +21,20 @@ namespace Mindbox.Quokka
     {
 	    private readonly string name;
 	    private readonly IReadOnlyList<ArgumentValue> arguments;
+	    private readonly int? callOrdinal;
 
 	    private readonly MethodCall methodCall;
 
-	    public MethodMember(string name, IEnumerable<ArgumentValue> arguments, Location location)
+	    public MethodMember(
+		    string name,
+		    IEnumerable<ArgumentValue> arguments,
+		    Location location,
+		    int? callOrdinal = null)
 			: base(location)
 	    {
 		    this.name = name;
 		    this.arguments = arguments.ToList().AsReadOnly();
+		    this.callOrdinal = callOrdinal;
 
 		    methodCall = BuildMethodCall();
 	    }
@@ -72,7 +78,7 @@ namespace Mindbox.Quokka
 				.Where(argumentValue => argumentValue != null)
 			    .ToList();
 
-		    return new MethodCall(name, argumentValues);
+		    return new MethodCall(name, argumentValues, callOrdinal);
 	    }
     }
 }

--- a/Engine/Quokka.Core/Templating/Visitors/Expressions/MemberVisitor.cs
+++ b/Engine/Quokka.Core/Templating/Visitors/Expressions/MemberVisitor.cs
@@ -38,10 +38,14 @@ namespace Mindbox.Quokka
 
 	    public override Member VisitMethodCall(QuokkaParser.MethodCallContext context)
 	    {
+		    var name = context.Identifier().GetText();
+		    var argumentList = context.argumentList();
+
 			return new MethodMember(
-				context.Identifier().GetText(),
-				context.argumentList().Accept(new ArgumentListVisitor(VisitingContext)),
-				GetLocationFromToken(context.Identifier().Symbol));
+				name,
+				argumentList.Accept(new ArgumentListVisitor(VisitingContext)),
+				GetLocationFromToken(context.Identifier().Symbol),
+				VisitingContext.GetNextCallOrdinal(name, argumentList.GetText()));
 	    }
     }
 }

--- a/Engine/Quokka.Core/Templating/Visitors/VisitingContext.cs
+++ b/Engine/Quokka.Core/Templating/Visitors/VisitingContext.cs
@@ -13,6 +13,7 @@
 // // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 
 using Mindbox.Quokka.Generated;
 
@@ -22,19 +23,42 @@ namespace Mindbox.Quokka
 	{
 		private readonly Func<VisitingContext, IQuokkaVisitor<StaticBlock>> staticBlockFactoryMethod;
 
+		private readonly HashSet<string> nonIdempotentMethodNames;
+
+		private readonly Dictionary<(string Name, string Arguments), int> nonIdempotentMethodCallCounts = new();
+
 		public SyntaxErrorListener ErrorListener { get; }
 
 		public VisitingContext(
 			SyntaxErrorListener errorListener,
-			Func<VisitingContext, IQuokkaVisitor<StaticBlock>> staticBlockFactoryMethod)
+			Func<VisitingContext, IQuokkaVisitor<StaticBlock>> staticBlockFactoryMethod,
+			IEnumerable<string> nonIdempotentMethodNames = null)
 		{
 			this.staticBlockFactoryMethod = staticBlockFactoryMethod;
+			this.nonIdempotentMethodNames = new HashSet<string>(
+				nonIdempotentMethodNames ?? Array.Empty<string>(),
+				StringComparer.OrdinalIgnoreCase);
 			ErrorListener = errorListener;
 		}
 
 		public IQuokkaVisitor<StaticBlock> CreateStaticBlockVisitor()
 		{
 			return staticBlockFactoryMethod(this);
+		}
+
+		public int? GetNextCallOrdinal(string methodName, string argumentsSource)
+		{
+			if (!nonIdempotentMethodNames.Contains(methodName))
+				return null;
+
+			var callKey = (methodName.ToLowerInvariant(), (argumentsSource ?? string.Empty).ToLowerInvariant());
+			var callOrdinal = nonIdempotentMethodCallCounts.TryGetValue(callKey, out var previousCallOrdinal)
+				? previousCallOrdinal + 1
+				: 1;
+
+			nonIdempotentMethodCallCounts[callKey] = callOrdinal;
+
+			return callOrdinal;
 		}
 	}
 }

--- a/Engine/Quokka.Tests/ParameterDiscovery/ModelDiscoveryNonIdempotentMethodsTests.cs
+++ b/Engine/Quokka.Tests/ParameterDiscovery/ModelDiscoveryNonIdempotentMethodsTests.cs
@@ -1,0 +1,129 @@
+// // Copyright 2022 Mindbox Ltd
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Mindbox.Quokka.Tests;
+
+namespace Mindbox.Quokka
+{
+	[TestClass]
+	public class ModelDiscoveryNonIdempotentMethodsTests
+	{
+		private static readonly string[] NonIdempotentMethodNames = { "SkipMemorized" };
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_IdenticalCalls_AreNumberedSeparately()
+		{
+			var modelDefinition = CreateTemplate("${ Object.SkipMemorized() }${ Object.SkipMemorized() }")
+				.GetModelDefinition();
+
+			AssertObjectMethodsDiscovered(
+				modelDefinition,
+				ExpectedCall("SkipMemorized", 1),
+				ExpectedCall("SkipMemorized", 2));
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_IdempotentMethod_IdenticalCalls_ShareASingleDefinition()
+		{
+			var modelDefinition = CreateTemplate("${ Object.GetValue() }${ Object.GetValue() }")
+				.GetModelDefinition();
+
+			AssertObjectMethodsDiscovered(modelDefinition, ExpectedCall("GetValue", null));
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_CallsAreNumberedPerArgumentList()
+		{
+			var modelDefinition = CreateTemplate(
+					@"
+						${ Object.SkipMemorized('a') }
+						${ Object.SkipMemorized('b') }
+						${ Object.SkipMemorized('a') }
+					")
+				.GetModelDefinition();
+
+			AssertObjectMethodsDiscovered(
+				modelDefinition,
+				ExpectedCall("SkipMemorized", 1, "a"),
+				ExpectedCall("SkipMemorized", 2, "a"),
+				ExpectedCall("SkipMemorized", 1, "b"));
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_NameMatchingIsCaseInsensitive()
+		{
+			var modelDefinition = CreateTemplate(
+					"${ Object.SkipMemorized() }${ Object.SkipMemorized() }",
+					new[] { "skipmemorized" })
+				.GetModelDefinition();
+
+			AssertObjectMethodsDiscovered(
+				modelDefinition,
+				ExpectedCall("SkipMemorized", 1),
+				ExpectedCall("SkipMemorized", 2));
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_HtmlTemplate_IdenticalCalls_AreNumberedSeparately()
+		{
+			var modelDefinition = new DefaultTemplateFactory(nonIdempotentMethodNames: NonIdempotentMethodNames)
+				.CreateHtmlTemplate("<p>${ Object.SkipMemorized() }${ Object.SkipMemorized() }</p>")
+				.GetModelDefinition();
+
+			AssertObjectMethodsDiscovered(
+				modelDefinition,
+				ExpectedCall("SkipMemorized", 1),
+				ExpectedCall("SkipMemorized", 2));
+		}
+
+		private static ITemplate CreateTemplate(string templateText) =>
+			CreateTemplate(templateText, NonIdempotentMethodNames);
+
+		private static ITemplate CreateTemplate(string templateText, IEnumerable<string> nonIdempotentMethodNames) =>
+			new DefaultTemplateFactory(nonIdempotentMethodNames: nonIdempotentMethodNames)
+				.CreateTemplate(templateText);
+
+		private static IMethodCallDefinition ExpectedCall(string name, int? callOrdinal, params string[] arguments) =>
+			new MethodCallDefinition(
+				name,
+				arguments
+					.Select(argument =>
+						(IMethodArgumentDefinition)new MethodArgumentDefinition(TypeDefinition.String, argument))
+					.ToArray(),
+				callOrdinal);
+
+		private static void AssertObjectMethodsDiscovered(
+			ICompositeModelDefinition modelDefinition,
+			params IMethodCallDefinition[] expectedCalls)
+		{
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Object", new CompositeModelDefinition(
+								methods: expectedCalls.ToDictionary(
+									expectedCall => expectedCall,
+									_ => (IModelDefinition)new PrimitiveModelDefinition(TypeDefinition.Primitive)))
+						}
+					}),
+				modelDefinition);
+		}
+	}
+}

--- a/Engine/Quokka.Tests/Rendering/RenderMethodCallsTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderMethodCallsTests.cs
@@ -43,6 +43,23 @@ namespace Mindbox.Quokka
 	    }
 
 	    [TestMethod]
+	    public void Render_NonIdempotentMethodCall_IdenticalCalls_RenderTheirOwnValues()
+	    {
+		    var template = new DefaultTemplateFactory(nonIdempotentMethodNames: new[] { "SkipMemorized" })
+			    .CreateTemplate("${ Object.SkipMemorized() }/${ Object.SkipMemorized() }");
+
+		    var result = template.Render(
+			    new CompositeModelValue(
+				    new ModelField(
+					    "Object",
+					    new CompositeModelValue(
+						    new ModelMethod("SkipMemorized", Array.Empty<object>(), "first", 1),
+						    new ModelMethod("SkipMemorized", Array.Empty<object>(), "second", 2)))));
+
+		    Assert.AreEqual("first/second", result);
+	    }
+
+	    [TestMethod]
 	    public void Render_MethodCall_WithoutArguments_MethodChain()
 	    {
 		    var template = new Template("${ Object.GetNumbers().First() }");


### PR DESCRIPTION
`TemplateFactory` now takes a set of method names that are not idempotent. While visiting a template the engine assigns every call of such a method a CallOrdinal — its 1-based number among the calls with the same name and argument list — and carries it through MethodCall, IMethodCallDefinition and IModelMethod. CallOrdinal takes part in equality, so two textually identical calls of a non-idempotent method no longer collapse into one entry of the model definition and the caller can supply a different value for each of them. Methods outside the set keep a null CallOrdinal and the previous behaviour.