### PR TITLE
Number the occurrences of non-idempotent method calls

### DIFF
--- a/Engine/Directory.Build.props
+++ b/Engine/Directory.Build.props
@@ -16,6 +16,6 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <VersionPrefix>8.5.0</VersionPrefix>
+        <VersionPrefix>8.6.0</VersionPrefix>
     </PropertyGroup>
 </Project>

--- a/Engine/Mindbox.Quokka.Abstractions/Model/Definitions/IMethodCallDefinition.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Model/Definitions/IMethodCallDefinition.cs
@@ -20,5 +20,10 @@ namespace Mindbox.Quokka
     {
         string Name { get; }
         IReadOnlyList<IMethodArgumentDefinition> Arguments { get; }
+
+        /// <summary>
+        /// Occurrence number of a non-idempotent method call (1-based), null for idempotent methods
+        /// </summary>
+        int? OccurrenceNumber => null;
     }
 }

--- a/Engine/Mindbox.Quokka.Abstractions/Model/InputValues/IModelMethod.cs
+++ b/Engine/Mindbox.Quokka.Abstractions/Model/InputValues/IModelMethod.cs
@@ -22,6 +22,11 @@ namespace Mindbox.Quokka
 
 		IReadOnlyList<object> Arguments { get; }
 
+		/// <summary>
+		/// Occurrence number of the call this value belongs to (1-based), null for idempotent methods
+		/// </summary>
+		int? OccurrenceNumber => null;
+
 	    IModelValue Value { get; }
 	}
 }

--- a/Engine/Quokka.Core/DefaultTemplateFactory.cs
+++ b/Engine/Quokka.Core/DefaultTemplateFactory.cs
@@ -12,6 +12,7 @@
 // // See the License for the specific language governing permissions and
 // // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -23,23 +24,36 @@ namespace Mindbox.Quokka
 	{
 		private readonly FunctionRegistry functionRegistry;
 
-		public DefaultTemplateFactory(IEnumerable<TemplateFunction> additionalFunctions = null)
+		private readonly IReadOnlyCollection<string> nonIdempotentMethodNames;
+
+		public DefaultTemplateFactory(
+			IEnumerable<TemplateFunction> additionalFunctions = null,
+			IEnumerable<string> nonIdempotentMethodNames = null)
 		{
 			var functions = new List<TemplateFunction>(Template.GetStandardFunctions());
 			if (additionalFunctions != null)
 				functions.AddRange(additionalFunctions);
 			
 			functionRegistry = new FunctionRegistry(functions);
+			this.nonIdempotentMethodNames = nonIdempotentMethodNames?.ToArray() ?? Array.Empty<string>();
 		}
 
 		public ITemplate CreateTemplate(string templateText)
 		{
-			return new Template(templateText, functionRegistry,  true);
+			return new Template(
+				templateText,
+				functionRegistry,
+				true,
+				nonIdempotentMethodNames: nonIdempotentMethodNames);
 		}
 
 		public ITemplate TryCreateTemplate(string templateText, out IList<ITemplateError> errors)
 		{
-			var template = new Template(templateText, functionRegistry, false);
+			var template = new Template(
+				templateText,
+				functionRegistry,
+				false,
+				nonIdempotentMethodNames: nonIdempotentMethodNames);
 			errors = template.Errors;
 
 			return errors.Any() ? null : template;
@@ -47,12 +61,12 @@ namespace Mindbox.Quokka
 
 		public IHtmlTemplate CreateHtmlTemplate(string templateText)
 		{
-			return new HtmlTemplate(templateText, functionRegistry, true);
+			return new HtmlTemplate(templateText, functionRegistry, true, nonIdempotentMethodNames);
 		}
 
 		public IHtmlTemplate TryCreateHtmlTemplate(string templateText, out IList<ITemplateError> errors)
 		{
-			var template = new HtmlTemplate(templateText, functionRegistry, false);
+			var template = new HtmlTemplate(templateText, functionRegistry, false, nonIdempotentMethodNames);
 			errors = template.Errors;
 
 			return errors.Any() ? null : template;

--- a/Engine/Quokka.Core/Html/HtmlTemplate.cs
+++ b/Engine/Quokka.Core/Html/HtmlTemplate.cs
@@ -27,13 +27,15 @@ namespace Mindbox.Quokka.Html
 		internal HtmlTemplate(
 			string templateText,
 			FunctionRegistry functionRegistry,
-			bool throwIfErrorsEncountered = true)
+			bool throwIfErrorsEncountered = true,
+			IEnumerable<string> nonIdempotentMethodNames = null)
 			: base(
 				templateText,
 				functionRegistry,
 				throwIfErrorsEncountered,
 				context => new HtmlStaticBlockVisitor(context),
-				new[] { new HtmlSemanticErrorSubListener() })
+				new[] { new HtmlSemanticErrorSubListener() },
+				nonIdempotentMethodNames)
 		{
 		}
 

--- a/Engine/Quokka.Core/Model/Definitions/MethodCallDefinition.cs
+++ b/Engine/Quokka.Core/Model/Definitions/MethodCallDefinition.cs
@@ -24,10 +24,16 @@ namespace Mindbox.Quokka
 
 		public IReadOnlyList<IMethodArgumentDefinition> Arguments { get; }
 
-	    internal MethodCallDefinition(string name, IReadOnlyList<IMethodArgumentDefinition> arguments)
+		public int? OccurrenceNumber { get; }
+
+	    internal MethodCallDefinition(
+		    string name,
+		    IReadOnlyList<IMethodArgumentDefinition> arguments,
+		    int? occurrenceNumber = null)
 	    {
 		    Name = name;
 		    Arguments = arguments;
+		    OccurrenceNumber = occurrenceNumber;
 	    }
 
 		public bool Equals(IMethodCallDefinition other)
@@ -36,6 +42,9 @@ namespace Mindbox.Quokka
 				return false;
 
 			if (!StringComparer.OrdinalIgnoreCase.Equals(Name, other.Name))
+				return false;
+
+			if (OccurrenceNumber != other.OccurrenceNumber)
 				return false;
 
 			if (Arguments.Count != other.Arguments.Count)
@@ -74,8 +83,12 @@ namespace Mindbox.Quokka
 			return StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
 		}
 
-		public override string ToString() => 
-			$"{Name}({string.Join(", ", Arguments.Select(arg => $"{arg.Type.Name}: {arg.Value}"))})";
+		public override string ToString()
+		{
+			var arguments = string.Join(", ", Arguments.Select(arg => $"{arg.Type.Name}: {arg.Value}"));
+
+			return OccurrenceNumber == null ? $"{Name}({arguments})" : $"{Name}({arguments})#{OccurrenceNumber}";
+		}
 	}
 
 

--- a/Engine/Quokka.Core/Model/InputValues/ModelMethod.cs
+++ b/Engine/Quokka.Core/Model/InputValues/ModelMethod.cs
@@ -24,6 +24,7 @@ namespace Mindbox.Quokka
     {
 		public string Name { get; }
 	    public IReadOnlyList<object> Arguments { get; }
+	    public int? OccurrenceNumber { get; }
 		public IModelValue Value { get; }
 
 	    public ModelMethod(string name, IModelValue value)
@@ -36,15 +37,16 @@ namespace Mindbox.Quokka
 	    {
 	    }
 		
-	    public ModelMethod(string name, IEnumerable<object> arguments, IModelValue value)
+	    public ModelMethod(string name, IEnumerable<object> arguments, IModelValue value, int? occurrenceNumber = null)
 	    {
 		    Name = name;
 		    Arguments = arguments.ToArray();
+		    OccurrenceNumber = occurrenceNumber;
 		    Value = value;
 	    }
 
-	    public ModelMethod(string name, IEnumerable<object> arguments, object primitiveValue)
-		    : this(name, arguments, new PrimitiveModelValue(primitiveValue))
+	    public ModelMethod(string name, IEnumerable<object> arguments, object primitiveValue, int? occurrenceNumber = null)
+		    : this(name, arguments, new PrimitiveModelValue(primitiveValue), occurrenceNumber)
 	    {
 	    }
 	}

--- a/Engine/Quokka.Core/Model/ModelValidator.cs
+++ b/Engine/Quokka.Core/Model/ModelValidator.cs
@@ -71,9 +71,7 @@ namespace Mindbox.Quokka
 
 			foreach (var requiredField in requiredFields)
 			{
-				var fieldFullName = modelPrefix == null
-										? requiredField.Key
-										: $"{modelPrefix}.{requiredField.Key}";
+				var fieldFullName = GetFullName(modelPrefix, requiredField.Key);
 
 				if (!actualFields.TryGetValue(requiredField.Key, out IModelField actualField))
 				{
@@ -101,26 +99,30 @@ namespace Mindbox.Quokka
 			var requiredMethods = requiredModelDefinition.Methods.ToList();
 			var actualMethods = model
 				.Methods
-				.ToDictionary(method => new MethodCall(method.Name, method.Arguments));
+				.GroupBy(method => new MethodCall(method.Name, method.Arguments, method.OccurrenceNumber))
+				.ToDictionary(group => group.Key, group => group.ToList());
 
 			foreach (var requiredMethod in requiredMethods)
 			{
-				var methodFullName = modelPrefix == null
-										? requiredMethod.Key.ToString()
-										: $"{modelPrefix}.{requiredMethod.Key}";
+				var methodFullName = GetFullName(modelPrefix, requiredMethod.Key);
 
 				var requiredMethodCall = new MethodCall(
 					requiredMethod.Key.Name,
-					requiredMethod.Key.Arguments.Select(arg => arg.Value).ToArray());
+					requiredMethod.Key.Arguments.Select(arg => arg.Value).ToArray(),
+					requiredMethod.Key.OccurrenceNumber);
 
-				if (!actualMethods.TryGetValue(requiredMethodCall, out IModelMethod actualMethod))
+				if (!actualMethods.TryGetValue(requiredMethodCall, out var actualMethodValues))
 				{
 					validationContext.AddError($"Method call result for {methodFullName} not found");
 				}
 				else
 				{
+					if (actualMethodValues.Count > 1)
+						validationContext.AddError(
+							$"Method call result for {methodFullName} is provided more than once");
+
 					var requiredValue = requiredMethod.Value;
-					var actualValue = actualMethod.Value;
+					var actualValue = actualMethodValues[0].Value;
 
 					if (actualValue == null)
 						validationContext.AddError($"Field {methodFullName} value is null");
@@ -128,6 +130,11 @@ namespace Mindbox.Quokka
 						ValidateValue(validationContext, requiredValue, actualValue, methodFullName);
 				}
 			}
+		}
+
+		private static string GetFullName(string modelPrefix, object member)
+		{
+			return modelPrefix == null ? member.ToString() : $"{modelPrefix}.{member}";
 		}
 
 		private void ValidateValue(

--- a/Engine/Quokka.Core/Rendering/Values/CompositeVariableValueStorage.cs
+++ b/Engine/Quokka.Core/Rendering/Values/CompositeVariableValueStorage.cs
@@ -42,7 +42,7 @@ namespace Mindbox.Quokka
 			methods = modelValue
 				.Methods
 				.ToDictionary(
-					method => new MethodCall(method.Name, method.Arguments), 
+					method => new MethodCall(method.Name, method.Arguments, method.OccurrenceNumber), 
 					method => method.Value != null ? CreateStorageForValue(method.Value) : null);
 		}
 

--- a/Engine/Quokka.Core/Semantics/AnalysisContext.cs
+++ b/Engine/Quokka.Core/Semantics/AnalysisContext.cs
@@ -13,11 +13,14 @@
 // // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 
 namespace Mindbox.Quokka
 {
 	internal class AnalysisContext
 	{
+		private readonly HashSet<string> nonIdempotentMethodNames;
+
 		public CompilationVariableScope VariableScope { get; }
 		public FunctionRegistry Functions { get; }
 		public ISemanticErrorListener ErrorListener { get; }
@@ -25,11 +28,33 @@ namespace Mindbox.Quokka
 		public AnalysisContext(
 			CompilationVariableScope variableScope,
 			FunctionRegistry functions,
-			ISemanticErrorListener errorListener)
+			ISemanticErrorListener errorListener,
+			IEnumerable<string> nonIdempotentMethodNames = null)
+			: this(
+				variableScope,
+				functions,
+				errorListener,
+				new HashSet<string>(
+					nonIdempotentMethodNames ?? Array.Empty<string>(),
+					StringComparer.OrdinalIgnoreCase))
+		{
+		}
+
+		private AnalysisContext(
+			CompilationVariableScope variableScope,
+			FunctionRegistry functions,
+			ISemanticErrorListener errorListener,
+			HashSet<string> nonIdempotentMethodNames)
 		{
 			VariableScope = variableScope;
 			Functions = functions;
 			ErrorListener = errorListener;
+			this.nonIdempotentMethodNames = nonIdempotentMethodNames;
+		}
+
+		public bool IsMethodNonIdempotent(string methodName)
+		{
+			return nonIdempotentMethodNames.Contains(methodName);
 		}
 
 		public AnalysisContext CreateNestedScopeContext()
@@ -37,7 +62,8 @@ namespace Mindbox.Quokka
 			return new AnalysisContext(
 				VariableScope.CreateChildScope(),
 				Functions,
-				ErrorListener);
+				ErrorListener,
+				nonIdempotentMethodNames);
 		}
 	}
 }

--- a/Engine/Quokka.Core/Semantics/Variables/MethodCall.cs
+++ b/Engine/Quokka.Core/Semantics/Variables/MethodCall.cs
@@ -22,12 +22,15 @@ namespace Mindbox.Quokka
     {
 		public string Name { get; }
 
+		public int? OccurrenceNumber { get; }
+
 	    private readonly IReadOnlyList<object> argumentValues;
 
-	    public MethodCall(string name, IReadOnlyList<object> argumentValues)
+	    public MethodCall(string name, IReadOnlyList<object> argumentValues, int? occurrenceNumber = null)
 	    {
 		    Name = name;
 		    this.argumentValues = argumentValues;
+		    OccurrenceNumber = occurrenceNumber;
 	    }
 
 	    public IMethodCallDefinition ToMethodCallDefinition()
@@ -39,7 +42,13 @@ namespace Mindbox.Quokka
 						    new MethodArgumentDefinition(
 							    TypeDefinition.GetTypeDefinitionByRuntimeType(argumentValue.GetType()),
 							    argumentValue))
-				    .ToArray());
+				    .ToArray(),
+			    OccurrenceNumber);
+	    }
+
+	    public MethodCall WithOccurrenceNumber(int occurrenceNumber)
+	    {
+		    return new MethodCall(Name, argumentValues, occurrenceNumber);
 	    }
 
 	    public bool Equals(MethodCall other)
@@ -49,6 +58,11 @@ namespace Mindbox.Quokka
 		    if (ReferenceEquals(this, other))
 			    return true;
 
+		    return OccurrenceNumber == other.OccurrenceNumber && HasSameSignature(other);
+	    }
+
+	    public bool HasSameSignature(MethodCall other)
+	    {
 		    if (!StringComparer.OrdinalIgnoreCase.Equals(Name, other.Name))
 			    return false;
 
@@ -91,7 +105,9 @@ namespace Mindbox.Quokka
 
 	    public override string ToString()
 	    {
-		    return $"{Name}({string.Join(", ", argumentValues)})";
+		    var arguments = string.Join(", ", argumentValues);
+
+		    return OccurrenceNumber == null ? $"{Name}({arguments})" : $"{Name}({arguments})#{OccurrenceNumber}";
 	    }
     }
 }

--- a/Engine/Quokka.Core/Template.cs
+++ b/Engine/Quokka.Core/Template.cs
@@ -44,7 +44,8 @@ namespace Mindbox.Quokka
 			FunctionRegistry functionRegistry,
 			bool throwIfErrorsEncountered = true,
 			Func<VisitingContext, IQuokkaVisitor<StaticBlock>> staticBlockVisitorCreator = null,
-			IEnumerable<SemanticErrorSubListenerBase> semanticErrorSubListeners = null)
+			IEnumerable<SemanticErrorSubListenerBase> semanticErrorSubListeners = null,
+			IEnumerable<string> nonIdempotentMethodNames = null)
 		{
 			ArgumentNullException.ThrowIfNull(templateText);
 			ArgumentNullException.ThrowIfNull(functionRegistry);
@@ -75,10 +76,11 @@ namespace Mindbox.Quokka
 
 					IsConstant = compiledTemplateTree.IsConstant;
 
-					var analysisContext = new AnalysisContext
-						(new CompilationVariableScope(),
+					var analysisContext = new AnalysisContext(
+						new CompilationVariableScope(),
 						functionRegistry,
-						semanticErrorListener);
+						semanticErrorListener,
+						nonIdempotentMethodNames);
 
 					compiledTemplateTree.PerformSemanticAnalysis(analysisContext);
 					analysisContext.VariableScope.Compile(analysisContext);

--- a/Engine/Quokka.Core/Templating/Expressions/Variables/MethodMember.cs
+++ b/Engine/Quokka.Core/Templating/Expressions/Variables/MethodMember.cs
@@ -22,7 +22,7 @@ namespace Mindbox.Quokka
 	    private readonly string name;
 	    private readonly IReadOnlyList<ArgumentValue> arguments;
 
-	    private readonly MethodCall methodCall;
+	    private MethodCall methodCall;
 
 	    public MethodMember(string name, IEnumerable<ArgumentValue> arguments, Location location)
 			: base(location)
@@ -38,6 +38,14 @@ namespace Mindbox.Quokka
 		    for (int i = 0; i < arguments.Count; i++)
 			    if (arguments[i].TryGetStaticValue() == null)
 				    analysisContext.ErrorListener.AddNonConstantMethodArgumentError(name, i + 1, Location);
+
+		    if (methodCall.OccurrenceNumber == null && analysisContext.IsMethodNonIdempotent(name))
+		    {
+			    var previousOccurrenceCount = ownerValueUsageSummary.Methods.Items
+				    .Count(item => item.Key.HasSameSignature(methodCall));
+
+			    methodCall = methodCall.WithOccurrenceNumber(previousOccurrenceCount + 1);
+		    }
 
 		    ownerValueUsageSummary.Methods
 			    .CreateOrUpdateMember(methodCall, new ValueUsage(Location, memberType));

--- a/Engine/Quokka.Tests/ModelValidation/ModelDefinitionCombiningTests.cs
+++ b/Engine/Quokka.Tests/ModelValidation/ModelDefinitionCombiningTests.cs
@@ -12,6 +12,7 @@
 // // See the License for the specific language governing permissions and
 // // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -259,6 +260,47 @@ namespace Mindbox.Quokka.Tests
 				new CompositeModelDefinition(new Dictionary<string, IModelDefinition>
 				{
 					{ "Primitive1", new PrimitiveModelDefinition(TypeDefinition.Integer) }
+				}),
+				combinedDefinition);
+		}
+
+		[TestMethod]
+		public void DefinitionCombining_NonIdempotentCalls_AreMatchedByOccurrenceNumber()
+		{
+			var factory = new DefaultTemplateFactory(nonIdempotentMethodNames: new[] { "Refresh" });
+
+			var definition1 = factory
+				.CreateTemplate("${ Object.Refresh().X }${ Object.Refresh().Y }")
+				.GetModelDefinition();
+			var definition2 = factory
+				.CreateTemplate("${ Object.Refresh().X }")
+				.GetModelDefinition();
+
+			var combinedDefinition = factory.CombineModelDefinition(new[] { definition1, definition2 });
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(new Dictionary<string, IModelDefinition>
+				{
+					{
+						"Object", new CompositeModelDefinition(
+							methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+							{
+								{
+									new MethodCallDefinition("Refresh", Array.Empty<IMethodArgumentDefinition>(), 1),
+									new CompositeModelDefinition(new Dictionary<string, IModelDefinition>
+									{
+										{ "X", new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+									})
+								},
+								{
+									new MethodCallDefinition("Refresh", Array.Empty<IMethodArgumentDefinition>(), 2),
+									new CompositeModelDefinition(new Dictionary<string, IModelDefinition>
+									{
+										{ "Y", new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+									})
+								}
+							})
+					}
 				}),
 				combinedDefinition);
 		}

--- a/Engine/Quokka.Tests/ParameterDiscovery/ModelDiscoveryOccurrenceNumbersTests.cs
+++ b/Engine/Quokka.Tests/ParameterDiscovery/ModelDiscoveryOccurrenceNumbersTests.cs
@@ -1,0 +1,319 @@
+﻿// // Copyright 2022 Mindbox Ltd
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Mindbox.Quokka.Tests;
+
+namespace Mindbox.Quokka
+{
+	[TestClass]
+	public class ModelDiscoveryOccurrenceNumbersTests
+	{
+		private static readonly string[] NonIdempotentMethodNames = { "Refresh" };
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_IdenticalCalls_GetSeparateDefinitions()
+		{
+			var modelDefinition = CreateTemplate("${ Object.Refresh() }${ Object.Refresh() }")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Object", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh(1), new PrimitiveModelDefinition(TypeDefinition.Primitive) },
+									{ Refresh(2), new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								})
+						}
+					}),
+				modelDefinition);
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_IdempotentMethod_IdenticalCalls_ShareASingleDefinition()
+		{
+			var modelDefinition = new Template("${ Object.Refresh() }${ Object.Refresh() }")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Object", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh(), new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								})
+						}
+					}),
+				modelDefinition);
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_CallsOnDifferentOwners_AreNumberedIndependently()
+		{
+			var modelDefinition = CreateTemplate(
+					"${ First.Refresh() }${ Second.Refresh() }${ First.Refresh() }")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"First", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh(1), new PrimitiveModelDefinition(TypeDefinition.Primitive) },
+									{ Refresh(2), new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								})
+						},
+						{
+							"Second", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh(1), new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								})
+						}
+					}),
+				modelDefinition);
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_CallsWithDifferentArguments_AreNumberedIndependently()
+		{
+			var modelDefinition = CreateTemplate(
+					"${ Object.Refresh('a') }${ Object.Refresh('b') }${ Object.Refresh('a') }")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Object", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh("a", 1), new PrimitiveModelDefinition(TypeDefinition.Primitive) },
+									{ Refresh("b", 1), new PrimitiveModelDefinition(TypeDefinition.Primitive) },
+									{ Refresh("a", 2), new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								})
+						}
+					}),
+				modelDefinition);
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethodName_IsMatchedCaseInsensitively()
+		{
+			var modelDefinition = new DefaultTemplateFactory(nonIdempotentMethodNames: new[] { "REFRESH" })
+				.CreateTemplate("${ Object.Refresh() }${ Object.Refresh() }")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Object", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh(1), new PrimitiveModelDefinition(TypeDefinition.Primitive) },
+									{ Refresh(2), new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								})
+						}
+					}),
+				modelDefinition);
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_HtmlTemplate_IdenticalCalls_GetSeparateDefinitions()
+		{
+			var modelDefinition = new DefaultTemplateFactory(nonIdempotentMethodNames: NonIdempotentMethodNames)
+				.CreateHtmlTemplate("<p>${ Object.Refresh() }${ Object.Refresh() }</p>")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Object", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh(1), new PrimitiveModelDefinition(TypeDefinition.Primitive) },
+									{ Refresh(2), new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								})
+						}
+					}),
+				modelDefinition);
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_IdenticalCallChains_GetSeparateResultDefinitions()
+		{
+			var modelDefinition = CreateTemplate(@"
+					@{ for item in Object.Refresh().GetItems() }${ item.Name }@{ end for }
+					@{ for item in Object.Refresh().GetItems() }${ item.Price }@{ end for }
+				")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Object", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh(1), ItemCollection("Name") },
+									{ Refresh(2), ItemCollection("Price") }
+								})
+						}
+					}),
+				modelDefinition);
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_CallsOnCollectionElement_ShareOneDefinition()
+		{
+			var modelDefinition = CreateTemplate(@"
+					@{ for a in Collection }${ a.Refresh().X }@{ end for }
+					@{ for b in Collection }${ b.Refresh().Y }@{ end for }
+				")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Collection", new ArrayModelDefinition(
+								new CompositeModelDefinition(
+									methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+									{
+										{
+											Refresh(1),
+											new CompositeModelDefinition(
+												new Dictionary<string, IModelDefinition>
+												{
+													{ "X", new PrimitiveModelDefinition(TypeDefinition.Primitive) },
+													{ "Y", new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+												})
+										}
+									}))
+						}
+					}),
+				modelDefinition);
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_CallsInConditionArms_GetSeparateDefinitions()
+		{
+			var modelDefinition = CreateTemplate(
+					"@{ if Flag }${ Object.Refresh() }@{ else }${ Object.Refresh() }@{ end if }")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{ "Flag", new PrimitiveModelDefinition(TypeDefinition.Boolean) },
+						{
+							"Object", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh(1), new PrimitiveModelDefinition(TypeDefinition.Primitive) },
+									{ Refresh(2), new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								})
+						}
+					}),
+				modelDefinition);
+		}
+
+		[TestMethod]
+		public void ModelDiscovery_NonIdempotentMethod_CallInLoopBody_IsNumberedOnce()
+		{
+			var modelDefinition = CreateTemplate(
+					"@{ for item in Collection }${ Object.Refresh() }@{ end for }")
+				.GetModelDefinition();
+
+			TemplateAssert.AreCompositeModelDefinitionsEqual(
+				new CompositeModelDefinition(
+					new Dictionary<string, IModelDefinition>
+					{
+						{
+							"Collection",
+							new ArrayModelDefinition(new PrimitiveModelDefinition(TypeDefinition.Unknown))
+						},
+						{
+							"Object", new CompositeModelDefinition(
+								methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+								{
+									{ Refresh(1), new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								})
+						}
+					}),
+				modelDefinition);
+		}
+
+		private static IModelDefinition ItemCollection(string itemFieldName)
+		{
+			return new CompositeModelDefinition(
+				methods: new Dictionary<IMethodCallDefinition, IModelDefinition>
+				{
+					{
+						new MethodCallDefinition("GetItems", Array.Empty<IMethodArgumentDefinition>()),
+						new ArrayModelDefinition(
+							new CompositeModelDefinition(
+								new Dictionary<string, IModelDefinition>
+								{
+									{ itemFieldName, new PrimitiveModelDefinition(TypeDefinition.Primitive) }
+								}))
+					}
+				});
+		}
+
+		private static MethodCallDefinition Refresh(int? occurrenceNumber = null)
+		{
+			return new MethodCallDefinition(
+				"Refresh",
+				Array.Empty<IMethodArgumentDefinition>(),
+				occurrenceNumber);
+		}
+
+		private static MethodCallDefinition Refresh(string argument, int? occurrenceNumber)
+		{
+			return new MethodCallDefinition(
+				"Refresh",
+				new[] { new MethodArgumentDefinition(TypeDefinition.String, argument) },
+				occurrenceNumber);
+		}
+
+		private static ITemplate CreateTemplate(string templateText)
+		{
+			return new DefaultTemplateFactory(nonIdempotentMethodNames: NonIdempotentMethodNames)
+				.CreateTemplate(templateText);
+		}
+	}
+}

--- a/Engine/Quokka.Tests/Rendering/RenderMethodCallsTests.cs
+++ b/Engine/Quokka.Tests/Rendering/RenderMethodCallsTests.cs
@@ -43,6 +43,41 @@ namespace Mindbox.Quokka
 	    }
 
 	    [TestMethod]
+	    public void Render_NonIdempotentMethodCalls_EachCallRendersItsOwnValue()
+	    {
+		    var template = new DefaultTemplateFactory(nonIdempotentMethodNames: new[] { "Refresh" })
+			    .CreateTemplate("${ Object.Refresh() }/${ Object.Refresh() }");
+
+		    var result = template.Render(
+			    new CompositeModelValue(
+				    new ModelField(
+					    "Object",
+					    new CompositeModelValue(
+						    new ModelMethod("Refresh", Array.Empty<object>(), "first", 1),
+						    new ModelMethod("Refresh", Array.Empty<object>(), "second", 2)))));
+
+		    Assert.AreEqual("first/second", result);
+	    }
+
+	    [TestMethod]
+	    public void Render_MethodCall_TwoValuesForTheSameCall_ReportsIt()
+	    {
+		    var template = new DefaultTemplateFactory(nonIdempotentMethodNames: new[] { "Refresh" })
+			    .CreateTemplate("${ Object.Refresh() }");
+
+		    var exception = Assert.ThrowsException<InvalidTemplateModelException>(
+			    () => template.Render(
+				    new CompositeModelValue(
+					    new ModelField(
+						    "Object",
+						    new CompositeModelValue(
+							    new ModelMethod("Refresh", Array.Empty<object>(), "first", 1),
+							    new ModelMethod("Refresh", Array.Empty<object>(), "second", 1))))));
+
+		    StringAssert.Contains(exception.Message, "is provided more than once");
+	    }
+
+	    [TestMethod]
 	    public void Render_MethodCall_WithoutArguments_MethodChain()
 	    {
 		    var template = new Template("${ Object.GetNumbers().First() }");


### PR DESCRIPTION
Identical method calls in a template share a single definition and a single value, which is wrong for a method whose repeated calls have to be evaluated separately.

A template factory now takes the names of such methods. Every call of one gets an OccurrenceNumber, its 1-based number among the identical calls registered on the same value, and that number is a part of the call identity, so such calls no longer share a definition. Calls of any other method are untouched and their OccurrenceNumber stays null.

A number belongs to a call site rather than to an evaluation: both arms of a condition get their own number and both have to be provided, a call in a loop body has a single number shared by all iterations, and two loops over one collection share a single definition for a call on the collection element.

Model validation now reports a model that provides more than one value for a call the template requires, instead of failing on a duplicate dictionary key.

Bumps the package version to 8.6.0.